### PR TITLE
Fix mb overload string functions

### DIFF
--- a/src/Stream/CallbackStream.php
+++ b/src/Stream/CallbackStream.php
@@ -91,7 +91,7 @@ class CallbackStream implements Stream
         }
 
         $render_url = $this->render->url($url);
-        $expected_bytes = $this->used_bytes + strlen($render_url) + strlen($this->end_string);
+        $expected_bytes = $this->used_bytes + mb_strlen($render_url, '8bit') + mb_strlen($this->end_string, '8bit');
 
         if ($expected_bytes > self::BYTE_LIMIT) {
             throw SizeOverflowException::withLimit(self::BYTE_LIMIT);
@@ -107,6 +107,6 @@ class CallbackStream implements Stream
     private function send(string $content): void
     {
         call_user_func($this->callback, $content);
-        $this->used_bytes += strlen($content);
+        $this->used_bytes += mb_strlen($content, '8bit');
     }
 }

--- a/src/Stream/OutputStream.php
+++ b/src/Stream/OutputStream.php
@@ -84,7 +84,7 @@ class OutputStream implements Stream
         }
 
         $render_url = $this->render->url($url);
-        $expected_bytes = $this->used_bytes + strlen($render_url) + strlen($this->end_string);
+        $expected_bytes = $this->used_bytes + mb_strlen($render_url, '8bit') + mb_strlen($this->end_string, '8bit');
 
         if ($expected_bytes > self::BYTE_LIMIT) {
             throw SizeOverflowException::withLimit(self::BYTE_LIMIT);
@@ -101,6 +101,6 @@ class OutputStream implements Stream
     {
         echo $content;
         flush();
-        $this->used_bytes += strlen($content);
+        $this->used_bytes += mb_strlen($content, '8bit');
     }
 }

--- a/src/Stream/RenderFileStream.php
+++ b/src/Stream/RenderFileStream.php
@@ -59,6 +59,11 @@ class RenderFileStream implements FileStream
     /**
      * @var int
      */
+    private $end_string_bytes = 0;
+
+    /**
+     * @var int
+     */
     private $used_bytes = 0;
 
     /**
@@ -90,9 +95,13 @@ class RenderFileStream implements FileStream
             throw FileAccessException::notWritable($this->tmp_filename);
         }
 
-        $this->write($this->render->start());
+        $start_string = $this->render->start();
+        $this->write($start_string);
+        $this->used_bytes += mb_strlen($start_string, '8bit');
+
         // render end string only once
         $this->end_string = $this->render->end();
+        $this->end_string_bytes = mb_strlen($this->end_string, '8bit');
     }
 
     public function close(): void
@@ -128,12 +137,13 @@ class RenderFileStream implements FileStream
 
         $render_url = $this->render->url($url);
 
-        $expected_bytes = $this->used_bytes + mb_strlen($render_url, '8bit') + mb_strlen($this->end_string, '8bit');
-        if ($expected_bytes > self::BYTE_LIMIT) {
+        $write_bytes = mb_strlen($render_url, '8bit');
+        if ($this->used_bytes + $write_bytes + $this->end_string_bytes > self::BYTE_LIMIT) {
             throw SizeOverflowException::withLimit(self::BYTE_LIMIT);
         }
 
         $this->write($render_url);
+        $this->used_bytes += $write_bytes;
         ++$this->counter;
     }
 
@@ -143,6 +153,5 @@ class RenderFileStream implements FileStream
     private function write(string $string): void
     {
         fwrite($this->handle, $string);
-        $this->used_bytes += mb_strlen($string, '8bit');
     }
 }

--- a/src/Stream/RenderFileStream.php
+++ b/src/Stream/RenderFileStream.php
@@ -128,7 +128,7 @@ class RenderFileStream implements FileStream
 
         $render_url = $this->render->url($url);
 
-        $expected_bytes = $this->used_bytes + strlen($render_url) + strlen($this->end_string);
+        $expected_bytes = $this->used_bytes + mb_strlen($render_url, '8bit') + mb_strlen($this->end_string, '8bit');
         if ($expected_bytes > self::BYTE_LIMIT) {
             throw SizeOverflowException::withLimit(self::BYTE_LIMIT);
         }
@@ -143,6 +143,6 @@ class RenderFileStream implements FileStream
     private function write(string $string): void
     {
         fwrite($this->handle, $string);
-        $this->used_bytes += strlen($string);
+        $this->used_bytes += mb_strlen($string, '8bit');
     }
 }


### PR DESCRIPTION
Use `mb_strlen($data, '8bit')` for correct calculate used bytes if mb overload string functions.