### PR TITLE
Render end string after render first url

### DIFF
--- a/src/Stream/OutputStream.php
+++ b/src/Stream/OutputStream.php
@@ -66,16 +66,12 @@ class OutputStream implements Stream
         $start_string = $this->render->start();
         $this->send($start_string);
         $this->used_bytes += mb_strlen($start_string, '8bit');
-
-        // render end string only once
-        $this->end_string = $this->render->end();
-        $this->end_string_bytes = mb_strlen($this->end_string, '8bit');
     }
 
     public function close(): void
     {
         $this->state->close();
-        $this->send($this->end_string);
+        $this->send($this->end_string ?: $this->render->end());
         $this->counter = 0;
         $this->used_bytes = 0;
     }
@@ -95,6 +91,13 @@ class OutputStream implements Stream
 
         $render_url = $this->render->url($url);
         $write_bytes = mb_strlen($render_url, '8bit');
+
+        // render end string after render first url
+        if (!$this->end_string) {
+            $this->end_string = $this->render->end();
+            $this->end_string_bytes = mb_strlen($this->end_string, '8bit');
+        }
+
         if ($this->used_bytes + $write_bytes + $this->end_string_bytes > self::BYTE_LIMIT) {
             throw SizeOverflowException::withLimit(self::BYTE_LIMIT);
         }

--- a/tests/Stream/CallbackStreamTest.php
+++ b/tests/Stream/CallbackStreamTest.php
@@ -182,6 +182,7 @@ class CallbackStreamTest extends TestCase
         ;
 
         $this->open();
+
         try {
             for ($i = 0; $i <= CallbackStream::LINKS_LIMIT; ++$i) {
                 $this->stream->push(new Url($loc));

--- a/tests/Stream/CallbackStreamTest.php
+++ b/tests/Stream/CallbackStreamTest.php
@@ -116,30 +116,48 @@ class CallbackStreamTest extends TestCase
             new Url('/bar'),
             new Url('/baz'),
         ];
+
         $call = 0;
         $this->stream = new CallbackStream($this->render, function ($content) use (&$call, $urls) {
-            if (isset($urls[$call - 1])) {
+            if ($call === 0) {
+                self::assertEquals(self::OPENED, $content);
+            } elseif (isset($urls[$call - 1])) {
                 self::assertEquals($urls[$call - 1]->getLoc(), $content);
+            } else {
+                self::assertEquals(self::CLOSED, $content);
             }
             ++$call;
         });
-        $this->open();
 
+        $render_call = 0;
+        $this->render
+            ->expects(self::at($render_call++))
+            ->method('start')
+            ->will(self::returnValue(self::OPENED))
+        ;
         foreach ($urls as $i => $url) {
             /* @var $url Url */
             $this->render
-                ->expects(self::at($i))
+                ->expects(self::at($render_call++))
                 ->method('url')
-                ->with($urls[$i])
+                ->with($url)
                 ->will(self::returnValue($url->getLoc()))
             ;
+            // render end string after first url
+            if ($i === 0) {
+                $this->render
+                    ->expects(self::at($render_call++))
+                    ->method('end')
+                    ->will(self::returnValue(self::CLOSED))
+                ;
+            }
         }
 
+        $this->stream->open();
         foreach ($urls as $url) {
             $this->stream->push($url);
         }
-
-        $this->close();
+        $this->stream->close();
     }
 
     public function testOverflowLinks(): void
@@ -156,13 +174,14 @@ class CallbackStreamTest extends TestCase
             }
             ++$call;
         });
-        $this->open();
+
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
             ->will(self::returnValue($loc))
         ;
 
+        $this->open();
         try {
             for ($i = 0; $i <= CallbackStream::LINKS_LIMIT; ++$i) {
                 $this->stream->push(new Url($loc));
@@ -183,7 +202,7 @@ class CallbackStreamTest extends TestCase
         $loc = str_repeat('/', $loop_size);
 
         $this->render
-            ->expects(self::at(0))
+            ->expects(self::once())
             ->method('start')
             ->will(self::returnValue($opened))
         ;
@@ -220,21 +239,20 @@ class CallbackStreamTest extends TestCase
     private function open(): void
     {
         $this->render
-            ->expects(self::at(0))
+            ->expects(self::once())
             ->method('start')
             ->will(self::returnValue(self::OPENED))
         ;
-        $this->render
-            ->expects(self::at(1))
-            ->method('end')
-            ->will(self::returnValue(self::CLOSED))
-        ;
-
         $this->stream->open();
     }
 
     private function close(): void
     {
+        $this->render
+            ->expects(self::once())
+            ->method('end')
+            ->will(self::returnValue(self::CLOSED))
+        ;
         $this->stream->close();
     }
 }

--- a/tests/Stream/RenderFileStreamTest.php
+++ b/tests/Stream/RenderFileStreamTest.php
@@ -134,7 +134,6 @@ class RenderFileStreamTest extends TestCase
 
     public function testPush(): void
     {
-
         $urls = [
             new Url('/foo'),
             new Url('/bar'),

--- a/tests/Stream/RenderFileStreamTest.php
+++ b/tests/Stream/RenderFileStreamTest.php
@@ -134,7 +134,6 @@ class RenderFileStreamTest extends TestCase
 
     public function testPush(): void
     {
-        $this->open();
 
         $urls = [
             new Url('/foo'),
@@ -142,22 +141,38 @@ class RenderFileStreamTest extends TestCase
             new Url('/baz'),
         ];
 
+        $this->expected_content .= self::OPENED;
+        $render_call = 0;
+        $this->render
+            ->expects(self::at($render_call++))
+            ->method('start')
+            ->will(self::returnValue(self::OPENED))
+        ;
         foreach ($urls as $i => $url) {
             /* @var $url Url */
             $this->render
-                ->expects(self::at($i))
+                ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($urls[$i])
                 ->will(self::returnValue($url->getLoc()))
             ;
+            // render end string after first url
+            if ($i === 0) {
+                $this->render
+                    ->expects(self::at($render_call++))
+                    ->method('end')
+                    ->will(self::returnValue(self::CLOSED))
+                ;
+            }
             $this->expected_content .= $url->getLoc();
         }
+        $this->expected_content .= self::CLOSED;
 
+        $this->stream->open();
         foreach ($urls as $url) {
             $this->stream->push($url);
         }
-
-        $this->close();
+        $this->stream->close();
     }
 
     public function testOverflowLinks(): void
@@ -186,7 +201,7 @@ class RenderFileStreamTest extends TestCase
         $loc = str_repeat('/', $loop_size);
 
         $this->render
-            ->expects(self::at(0))
+            ->expects(self::once())
             ->method('start')
             ->will(self::returnValue(str_repeat('/', $prefix_size)))
         ;
@@ -206,14 +221,9 @@ class RenderFileStreamTest extends TestCase
     private function open(): void
     {
         $this->render
-            ->expects(self::at(0))
+            ->expects(self::once())
             ->method('start')
             ->will(self::returnValue(self::OPENED))
-        ;
-        $this->render
-            ->expects(self::at(1))
-            ->method('end')
-            ->will(self::returnValue(self::CLOSED))
         ;
 
         $this->stream->open();
@@ -222,6 +232,11 @@ class RenderFileStreamTest extends TestCase
 
     private function close(): void
     {
+        $this->render
+            ->expects(self::once())
+            ->method('end')
+            ->will(self::returnValue(self::CLOSED))
+        ;
         $this->stream->close();
         $this->expected_content .= self::CLOSED;
     }


### PR DESCRIPTION
Render the end string after render first url. This is necessary for correct work [XMLWriter](https://www.php.net/manual/en/book.xmlwriter.php) #20.
If we render the end string after open and before the first URL, then we will get the incorrect XML code.

```php
$xml = new XMLWriter();               
$xml->openMemory();
$xml->setIndent(true);
$xml->startDocument('1.0', 'utf-8');

$xml->startElement('urlset');
$xml->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
$start = $xml->flush();

$xml->endElement();
$end = $xml->flush();


$xml->startElement('url');
$xml->writeElement('loc', 'https://example.com/');
$xml->writeElement('lastmod', '2019-08-12 13:09:27');
$xml->writeElement('changefreq', 'daily');
$xml->writeElement('priority', '1.0');
$xml->endElement();
$content = $xml->flush();

echo $start.$content.$end;
```
Result:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"<url>
 <loc>https://example.com/</loc>
 <lastmod>2019-08-12 13:09:27</lastmod>
 <changefreq>daily</changefreq>
 <priority>1.0</priority>
</url>
/>
```