### PR TITLE
No throw exception in StreamState::__destruct()

### DIFF
--- a/src/Stream/Exception/StreamStateException.php
+++ b/src/Stream/Exception/StreamStateException.php
@@ -44,12 +44,4 @@ final class StreamStateException extends \RuntimeException
     {
         return new self('Stream not ready.');
     }
-
-    /**
-     * @return self
-     */
-    public static function notClosed(): self
-    {
-        return new self('Stream not closed.');
-    }
 }

--- a/src/Stream/State/StreamState.php
+++ b/src/Stream/State/StreamState.php
@@ -60,14 +60,4 @@ final class StreamState
     {
         return $this->state == self::STATE_READY;
     }
-
-    /**
-     * Did you not forget to close the stream?
-     */
-    public function __destruct()
-    {
-        if ($this->state == self::STATE_READY) {
-            throw StreamStateException::notClosed();
-        }
-    }
 }

--- a/tests/Stream/State/StreamStateTest.php
+++ b/tests/Stream/State/StreamStateTest.php
@@ -67,14 +67,6 @@ class StreamStateTest extends TestCase
         $this->state->close();
     }
 
-    public function testNotClosed(): void
-    {
-        $this->expectException(StreamStateException::class);
-        $state = new StreamState();
-        $state->open();
-        unset($state);
-    }
-
     public function testAllIsGood(): void
     {
         $state = new StreamState();


### PR DESCRIPTION
If the program terminated with an error and the stream was not closed, a new exception will be generated that will override the main error. This makes it difficult to debug the main error and determine the root cause of the program crash.

Example. The cause of the failure was not a not closed stream.

```
PHP Fatal error:  Uncaught GpsLab\Component\Sitemap\Stream\Exception\StreamStateException: Stream not closed. in /sitemap/src/Stream/Exception/StreamStateException.php:53
Stack trace:
#0 /sitemap/src/Stream/State/StreamState.php(70): GpsLab\Component\Sitemap\Stream\Exception\StreamStateException::notClosed()
#1 [internal function]: GpsLab\Component\Sitemap\Stream\State\StreamState->__destruct()
#2 {main}
  thrown in /sitemap/src/Stream/Exception/StreamStateException.php on line 53
PHP Stack trace:
PHP   1. {main}() /sitemap/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit\TextUI\Command::main() /sitemap/vendor/phpunit/phpunit/phpunit:61
PHP   3. PHPUnit\TextUI\Command->run() /sitemap/vendor/phpunit/phpunit/src/TextUI/Command.php:162
PHP   4. PHPUnit\TextUI\TestRunner->doRun() /sitemap/vendor/phpunit/phpunit/src/TextUI/Command.php:206
```