### PR TITLE
Refactor URL class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,3 +16,5 @@
 * The `$compression_level` in `RenderGzipFileStream` can be only integer.
 * Move `CHANGE_FREQ_*` constants from `URL` class to new `ChangeFreq` class.
 * Mark `STATE_*` constants in `StreamState` class as private.
+* The `Url::getLoc()` was renamed to `Url::getLocation()` method.
+* The `Url::getLastMod()` was renamed to `Url::getLastModify()` method.

--- a/src/Render/PlainTextSitemapIndexRender.php
+++ b/src/Render/PlainTextSitemapIndexRender.php
@@ -16,7 +16,7 @@ class PlainTextSitemapIndexRender implements SitemapIndexRender
     /**
      * @var string
      */
-    private $host = '';
+    private $host;
 
     /**
      * @param string $host
@@ -45,15 +45,15 @@ class PlainTextSitemapIndexRender implements SitemapIndexRender
 
     /**
      * @param string                  $path
-     * @param \DateTimeInterface|null $last_mod
+     * @param \DateTimeInterface|null $last_modify
      *
      * @return string
      */
-    public function sitemap(string $path, \DateTimeInterface $last_mod = null): string
+    public function sitemap(string $path, \DateTimeInterface $last_modify = null): string
     {
         return '<sitemap>'.
             '<loc>'.$this->host.$path.'</loc>'.
-            ($last_mod ? sprintf('<lastmod>%s</lastmod>', $last_mod->format('c')) : '').
+            ($last_modify ? sprintf('<lastmod>%s</lastmod>', $last_modify->format('c')) : '').
         '</sitemap>';
     }
 }

--- a/src/Render/PlainTextSitemapRender.php
+++ b/src/Render/PlainTextSitemapRender.php
@@ -40,8 +40,8 @@ class PlainTextSitemapRender implements SitemapRender
     public function url(Url $url): string
     {
         return '<url>'.
-            '<loc>'.htmlspecialchars($url->getLoc()).'</loc>'.
-            '<lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.
+            '<loc>'.htmlspecialchars($url->getLocation()).'</loc>'.
+            '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
             '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
             '<priority>'.$url->getPriority().'</priority>'.
         '</url>';

--- a/src/Render/SitemapIndexRender.php
+++ b/src/Render/SitemapIndexRender.php
@@ -25,9 +25,9 @@ interface SitemapIndexRender
 
     /**
      * @param string                  $path
-     * @param \DateTimeInterface|null $last_mod
+     * @param \DateTimeInterface|null $last_modify
      *
      * @return string
      */
-    public function sitemap(string $path, \DateTimeInterface $last_mod = null): string;
+    public function sitemap(string $path, ?\DateTimeInterface $last_modify = null): string;
 }

--- a/src/Render/XMLWriterSitemapIndexRender.php
+++ b/src/Render/XMLWriterSitemapIndexRender.php
@@ -21,12 +21,12 @@ class XMLWriterSitemapIndexRender implements SitemapIndexRender
     /**
      * @var string
      */
-    private $host = '';
+    private $host;
 
     /**
      * @var bool
      */
-    private $use_indent = false;
+    private $use_indent;
 
     /**
      * @param string $host
@@ -86,11 +86,11 @@ class XMLWriterSitemapIndexRender implements SitemapIndexRender
 
     /**
      * @param string                  $path
-     * @param \DateTimeInterface|null $last_mod
+     * @param \DateTimeInterface|null $last_modify
      *
      * @return string
      */
-    public function sitemap(string $path, \DateTimeInterface $last_mod = null): string
+    public function sitemap(string $path, \DateTimeInterface $last_modify = null): string
     {
         if (!$this->writer) {
             $this->start();
@@ -98,8 +98,8 @@ class XMLWriterSitemapIndexRender implements SitemapIndexRender
 
         $this->writer->startElement('sitemap');
         $this->writer->writeElement('loc', $this->host.$path);
-        if ($last_mod) {
-            $this->writer->writeElement('lastmod', $last_mod->format('c'));
+        if ($last_modify) {
+            $this->writer->writeElement('lastmod', $last_modify->format('c'));
         }
         $this->writer->endElement();
 

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -23,7 +23,7 @@ class XMLWriterSitemapRender implements SitemapRender
     /**
      * @var bool
      */
-    private $use_indent = false;
+    private $use_indent;
 
     /**
      * @param bool $use_indent

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -91,8 +91,8 @@ class XMLWriterSitemapRender implements SitemapRender
         }
 
         $this->writer->startElement('url');
-        $this->writer->writeElement('loc', $url->getLoc());
-        $this->writer->writeElement('lastmod', $url->getLastMod()->format('c'));
+        $this->writer->writeElement('loc', $url->getLocation());
+        $this->writer->writeElement('lastmod', $url->getLastModify()->format('c'));
         $this->writer->writeElement('changefreq', $url->getChangeFreq());
         $this->writer->writeElement('priority', $url->getPriority());
         $this->writer->endElement();

--- a/src/Stream/LoggerStream.php
+++ b/src/Stream/LoggerStream.php
@@ -44,9 +44,9 @@ class LoggerStream implements Stream
      */
     public function push(Url $url): void
     {
-        $this->logger->debug(sprintf('URL "%s" was added to sitemap.xml', $url->getLoc()), [
+        $this->logger->debug(sprintf('URL "%s" was added to sitemap.xml', $url->getLocation()), [
             'changefreq' => $url->getChangeFreq(),
-            'lastmod' => $url->getLastMod(),
+            'lastmod' => $url->getLastModify(),
             'priority' => $url->getPriority(),
         ]);
     }

--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -18,10 +18,10 @@ class MultiStream implements Stream
     /**
      * @var Stream[]
      */
-    private $streams = [];
+    private $streams;
 
     /**
-     * @param Stream ...$streams
+     * @param Stream[] $streams
      */
     public function __construct(Stream ...$streams)
     {

--- a/src/Stream/RenderFileStream.php
+++ b/src/Stream/RenderFileStream.php
@@ -39,12 +39,12 @@ class RenderFileStream implements FileStream
     /**
      * @var string
      */
-    private $filename = '';
+    private $filename;
 
     /**
      * @var string
      */
-    private $tmp_filename = '';
+    private $tmp_filename;
 
     /**
      * @var int

--- a/src/Stream/RenderFileStream.php
+++ b/src/Stream/RenderFileStream.php
@@ -70,7 +70,7 @@ class RenderFileStream implements FileStream
      * @param SitemapRender $render
      * @param string        $filename
      */
-    public function __construct(SitemapRender $render, $filename)
+    public function __construct(SitemapRender $render, string $filename)
     {
         $this->render = $render;
         $this->state = new StreamState();

--- a/src/Stream/RenderGzipFileStream.php
+++ b/src/Stream/RenderGzipFileStream.php
@@ -40,17 +40,17 @@ class RenderGzipFileStream implements FileStream
     /**
      * @var string
      */
-    private $filename = '';
+    private $filename;
 
     /**
      * @var string
      */
-    private $tmp_filename = '';
+    private $tmp_filename;
 
     /**
      * @var int
      */
-    private $compression_level = 9;
+    private $compression_level;
 
     /**
      * @var int

--- a/src/Stream/RenderIndexFileStream.php
+++ b/src/Stream/RenderIndexFileStream.php
@@ -43,12 +43,12 @@ class RenderIndexFileStream implements FileStream
     /**
      * @var string
      */
-    private $filename = '';
+    private $filename;
 
     /**
      * @var string
      */
-    private $tmp_filename = '';
+    private $tmp_filename;
 
     /**
      * @var int

--- a/src/Stream/RenderIndexFileStream.php
+++ b/src/Stream/RenderIndexFileStream.php
@@ -201,14 +201,11 @@ class RenderIndexFileStream implements FileStream
     private function removeOldParts(): void
     {
         $filename = $this->substream->getFilename();
-        for ($i = $this->index + 1; true; ++$i) {
-            $indexed_filename = $this->getIndexPartFilename($filename, $i);
-            $target = dirname($this->filename).'/'.$indexed_filename;
-            if (file_exists($target)) {
-                unlink($target);
-            } else {
-                break;
-            }
+        $path = dirname($this->filename).'/';
+        $index = $this->index + 1;
+        while (file_exists($target = $path.$this->getIndexPartFilename($filename, $index))) {
+            unlink($target);
+            ++$index;
         }
     }
 }

--- a/src/Stream/RenderIndexFileStream.php
+++ b/src/Stream/RenderIndexFileStream.php
@@ -176,7 +176,7 @@ class RenderIndexFileStream implements FileStream
 
         [$filename, $extension] = explode('.', basename($path), 2) + ['', ''];
 
-        return sprintf('%s%s.%s', $filename, $index, $extension);
+        return sprintf('%s%s.%s', $filename ?: 'sitemap', $index, $extension ?: 'xml');
     }
 
     /**

--- a/src/Stream/RenderIndexFileStream.php
+++ b/src/Stream/RenderIndexFileStream.php
@@ -147,11 +147,9 @@ class RenderIndexFileStream implements FileStream
         $filename = $this->substream->getFilename();
         $indexed_filename = $this->getIndexPartFilename($filename, ++$this->index);
 
-        if (!file_exists($filename) || !($time = filemtime($filename))) {
+        if (!file_exists($filename)) {
             throw FileAccessException::notReadable($filename);
         }
-
-        $last_mod = (new \DateTimeImmutable())->setTimestamp($time);
 
         // rename sitemap file to sitemap part
         $new_filename = sys_get_temp_dir().'/'.$indexed_filename;
@@ -159,7 +157,7 @@ class RenderIndexFileStream implements FileStream
             throw FileAccessException::failedOverwrite($filename, $new_filename);
         }
 
-        fwrite($this->handle, $this->render->sitemap($indexed_filename, $last_mod));
+        fwrite($this->handle, $this->render->sitemap($indexed_filename, new \DateTimeImmutable()));
     }
 
     /**

--- a/src/Url/ChangeFreq.php
+++ b/src/Url/ChangeFreq.php
@@ -42,21 +42,22 @@ final class ChangeFreq
     ];
 
     /**
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      *
      * @return string|null
      */
-    public static function getByLastMod(\DateTimeInterface $last_mod): ?string
+    public static function getByLastMod(\DateTimeInterface $last_modify): ?string
     {
-        if ($last_mod < new \DateTime('-1 year')) {
+        $now = new \DateTimeImmutable();
+        if ($last_modify < $now->modify('-1 year')) {
             return self::YEARLY;
         }
 
-        if ($last_mod < new \DateTime('-1 month')) {
+        if ($last_modify < $now->modify('-1 month')) {
             return self::MONTHLY;
         }
 
-        if ($last_mod < new \DateTime('-1 week')) {
+        if ($last_modify < $now->modify('-1 week')) {
             return self::WEEKLY;
         }
 

--- a/src/Url/ChangeFreq.php
+++ b/src/Url/ChangeFreq.php
@@ -46,7 +46,7 @@ final class ChangeFreq
      *
      * @return string|null
      */
-    public static function getByLastMod(\DateTimeInterface $last_modify): ?string
+    public static function getByLastModify(\DateTimeInterface $last_modify): ?string
     {
         $now = new \DateTimeImmutable();
         if ($last_modify < $now->modify('-1 year')) {

--- a/src/Url/Priority.php
+++ b/src/Url/Priority.php
@@ -36,14 +36,14 @@ final class Priority
     public const P0 = '0.0';
 
     /**
-     * @param string $loc
+     * @param string $location
      *
      * @return string
      */
-    public static function getByLoc(string $loc): string
+    public static function getByLoc(string $location): string
     {
         // number of slashes
-        $num = count(array_filter(explode('/', trim($loc, '/'))));
+        $num = count(array_filter(explode('/', trim($location, '/'))));
 
         if (!$num) {
             return '1.0';

--- a/src/Url/Priority.php
+++ b/src/Url/Priority.php
@@ -40,7 +40,7 @@ final class Priority
      *
      * @return string
      */
-    public static function getByLoc(string $location): string
+    public static function getByLocation(string $location): string
     {
         // number of slashes
         $num = count(array_filter(explode('/', trim($location, '/'))));

--- a/src/Url/SmartUrl.php
+++ b/src/Url/SmartUrl.php
@@ -27,12 +27,12 @@ class SmartUrl extends Url
     ) {
         // priority from loc
         if (!$priority) {
-            $priority = Priority::getByLoc($location);
+            $priority = Priority::getByLocation($location);
         }
 
         // change freq from last mod
         if (!$change_freq && $last_modify instanceof \DateTimeInterface) {
-            $change_freq = ChangeFreq::getByLastMod($last_modify);
+            $change_freq = ChangeFreq::getByLastModify($last_modify);
         }
 
         // change freq from priority

--- a/src/Url/SmartUrl.php
+++ b/src/Url/SmartUrl.php
@@ -14,25 +14,25 @@ namespace GpsLab\Component\Sitemap\Url;
 class SmartUrl extends Url
 {
     /**
-     * @param string                  $loc
-     * @param \DateTimeInterface|null $last_mod
+     * @param string                  $location
+     * @param \DateTimeInterface|null $last_modify
      * @param string|null             $change_freq
      * @param string|null             $priority
      */
     public function __construct(
-        string $loc,
-        ?\DateTimeInterface $last_mod = null,
+        string $location,
+        ?\DateTimeInterface $last_modify = null,
         ?string $change_freq = null,
         ?string $priority = null
     ) {
         // priority from loc
         if (!$priority) {
-            $priority = Priority::getByLoc($loc);
+            $priority = Priority::getByLoc($location);
         }
 
         // change freq from last mod
-        if (!$change_freq && $last_mod instanceof \DateTimeInterface) {
-            $change_freq = ChangeFreq::getByLastMod($last_mod);
+        if (!$change_freq && $last_modify instanceof \DateTimeInterface) {
+            $change_freq = ChangeFreq::getByLastMod($last_modify);
         }
 
         // change freq from priority
@@ -40,6 +40,6 @@ class SmartUrl extends Url
             $change_freq = ChangeFreq::getByPriority($priority);
         }
 
-        parent::__construct($loc, $last_mod, $change_freq, $priority);
+        parent::__construct($location, $last_modify, $change_freq, $priority);
     }
 }

--- a/src/Url/Url.php
+++ b/src/Url/Url.php
@@ -20,37 +20,37 @@ class Url
     /**
      * @var string
      */
-    private $loc = '';
+    private $location;
 
     /**
      * @var \DateTimeInterface
      */
-    private $last_mod;
+    private $last_modify;
 
     /**
      * @var string
      */
-    private $change_freq = '';
+    private $change_freq;
 
     /**
      * @var string
      */
-    private $priority = '';
+    private $priority;
 
     /**
-     * @param string                  $loc
-     * @param \DateTimeInterface|null $last_mod
+     * @param string                  $location
+     * @param \DateTimeInterface|null $last_modify
      * @param string|null             $change_freq
      * @param string|null             $priority
      */
     public function __construct(
-        string $loc,
-        ?\DateTimeInterface $last_mod = null,
+        string $location,
+        ?\DateTimeInterface $last_modify = null,
         ?string $change_freq = null,
         ?string $priority = null
     ) {
-        $this->loc = $loc;
-        $this->last_mod = $last_mod ?: new \DateTimeImmutable();
+        $this->location = $location;
+        $this->last_modify = $last_modify ?: new \DateTimeImmutable();
         $this->change_freq = $change_freq ?: self::DEFAULT_CHANGE_FREQ;
         $this->priority = $priority ?: self::DEFAULT_PRIORITY;
     }
@@ -60,7 +60,7 @@ class Url
      */
     public function getLoc(): string
     {
-        return $this->loc;
+        return $this->location;
     }
 
     /**
@@ -68,7 +68,7 @@ class Url
      */
     public function getLastMod(): \DateTimeInterface
     {
-        return $this->last_mod;
+        return $this->last_modify;
     }
 
     /**

--- a/src/Url/Url.php
+++ b/src/Url/Url.php
@@ -58,7 +58,7 @@ class Url
     /**
      * @return string
      */
-    public function getLoc(): string
+    public function getLocation(): string
     {
         return $this->location;
     }
@@ -66,7 +66,7 @@ class Url
     /**
      * @return \DateTimeInterface
      */
-    public function getLastMod(): \DateTimeInterface
+    public function getLastModify(): \DateTimeInterface
     {
         return $this->last_modify;
     }

--- a/tests/Builder/Url/MultiUrlBuilderTest.php
+++ b/tests/Builder/Url/MultiUrlBuilderTest.php
@@ -52,7 +52,7 @@ class MultiUrlBuilderTest extends TestCase
         $builder
             ->expects(self::once())
             ->method('getIterator')
-            ->will(self::returnValue(new \ArrayIterator($builder_urls)))
+            ->willReturn(new \ArrayIterator($builder_urls))
         ;
 
         return $builder;

--- a/tests/Render/PlainTextSitemapIndexRenderTest.php
+++ b/tests/Render/PlainTextSitemapIndexRenderTest.php
@@ -71,18 +71,18 @@ class PlainTextSitemapIndexRenderTest extends TestCase
     /**
      * @dataProvider getLastMod
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      */
-    public function testSitemapWithLastMod(\DateTimeInterface $last_mod): void
+    public function testSitemapWithLastMod(\DateTimeInterface $last_modify): void
     {
         $path = '/sitemap1.xml';
 
         $expected = '<sitemap>'.
             '<loc>'.$this->host.$path.'</loc>'.
-            ($last_mod ? sprintf('<lastmod>%s</lastmod>', $last_mod->format('c')) : '').
+            ($last_modify ? sprintf('<lastmod>%s</lastmod>', $last_modify->format('c')) : '').
         '</sitemap>';
 
-        self::assertEquals($expected, $this->render->sitemap($path, $last_mod));
+        self::assertEquals($expected, $this->render->sitemap($path, $last_modify));
     }
 
     public function testStreamRender(): void

--- a/tests/Render/PlainTextSitemapRenderTest.php
+++ b/tests/Render/PlainTextSitemapRenderTest.php
@@ -53,8 +53,8 @@ class PlainTextSitemapRenderTest extends TestCase
         );
 
         $expected = '<url>'.
-            '<loc>'.htmlspecialchars($url->getLoc()).'</loc>'.
-            '<lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.
+            '<loc>'.htmlspecialchars($url->getLocation()).'</loc>'.
+            '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
             '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
             '<priority>'.$url->getPriority().'</priority>'.
             '</url>'
@@ -87,14 +87,14 @@ class PlainTextSitemapRenderTest extends TestCase
         $expected = '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL.
             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.
                 '<url>'.
-                    '<loc>'.htmlspecialchars($url1->getLoc()).'</loc>'.
-                    '<lastmod>'.$url1->getLastMod()->format('c').'</lastmod>'.
+                    '<loc>'.htmlspecialchars($url1->getLocation()).'</loc>'.
+                    '<lastmod>'.$url1->getLastModify()->format('c').'</lastmod>'.
                     '<changefreq>'.$url1->getChangeFreq().'</changefreq>'.
                     '<priority>'.$url1->getPriority().'</priority>'.
                 '</url>'.
                 '<url>'.
-                    '<loc>'.htmlspecialchars($url2->getLoc()).'</loc>'.
-                    '<lastmod>'.$url2->getLastMod()->format('c').'</lastmod>'.
+                    '<loc>'.htmlspecialchars($url2->getLocation()).'</loc>'.
+                    '<lastmod>'.$url2->getLastModify()->format('c').'</lastmod>'.
                     '<changefreq>'.$url2->getChangeFreq().'</changefreq>'.
                     '<priority>'.$url2->getPriority().'</priority>'.
                 '</url>'.

--- a/tests/Render/XMLWriterSitemapIndexRenderTest.php
+++ b/tests/Render/XMLWriterSitemapIndexRenderTest.php
@@ -119,9 +119,9 @@ class XMLWriterSitemapIndexRenderTest extends TestCase
     /**
      * @dataProvider getLastMod
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      */
-    public function testSitemapWithLastMod(\DateTimeInterface $last_mod): void
+    public function testSitemapWithLastMod(\DateTimeInterface $last_modify): void
     {
         $path = '/sitemap1.xml';
 
@@ -129,12 +129,12 @@ class XMLWriterSitemapIndexRenderTest extends TestCase
             '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL.
                 '<sitemap>'.
                     '<loc>'.$this->host.$path.'</loc>'.
-                    '<lastmod>'.$last_mod->format('c').'</lastmod>'.
+                    '<lastmod>'.$last_modify->format('c').'</lastmod>'.
                 '</sitemap>'.
             '</sitemapindex>'.PHP_EOL
         ;
 
-        $actual = $this->render->start().$this->render->sitemap($path, $last_mod).$this->render->end();
+        $actual = $this->render->start().$this->render->sitemap($path, $last_modify).$this->render->end();
         self::assertEquals($expected, $actual);
     }
 

--- a/tests/Render/XMLWriterSitemapRenderTest.php
+++ b/tests/Render/XMLWriterSitemapRenderTest.php
@@ -71,8 +71,8 @@ class XMLWriterSitemapRenderTest extends TestCase
 
         $expected =
             '<url>'.
-                '<loc>'.htmlspecialchars($url->getLoc()).'</loc>'.
-                '<lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.
+                '<loc>'.htmlspecialchars($url->getLocation()).'</loc>'.
+                '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
                 '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
                 '<priority>'.$url->getPriority().'</priority>'.
             '</url>'
@@ -93,8 +93,8 @@ class XMLWriterSitemapRenderTest extends TestCase
 
         $expected =
             ' <url>'.PHP_EOL.
-            '  <loc>'.htmlspecialchars($url->getLoc()).'</loc>'.PHP_EOL.
-            '  <lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.PHP_EOL.
+            '  <loc>'.htmlspecialchars($url->getLocation()).'</loc>'.PHP_EOL.
+            '  <lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.PHP_EOL.
             '  <changefreq>'.$url->getChangeFreq().'</changefreq>'.PHP_EOL.
             '  <priority>'.$url->getPriority().'</priority>'.PHP_EOL.
             ' </url>'.PHP_EOL
@@ -115,8 +115,8 @@ class XMLWriterSitemapRenderTest extends TestCase
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.
             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL.
                 '<url>'.
-                    '<loc>'.htmlspecialchars($url->getLoc()).'</loc>'.
-                    '<lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.
+                    '<loc>'.htmlspecialchars($url->getLocation()).'</loc>'.
+                    '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
                     '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
                     '<priority>'.$url->getPriority().'</priority>'.
                 '</url>'.
@@ -139,8 +139,8 @@ class XMLWriterSitemapRenderTest extends TestCase
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.
             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL.
             ' <url>'.PHP_EOL.
-            '  <loc>'.htmlspecialchars($url->getLoc()).'</loc>'.PHP_EOL.
-            '  <lastmod>'.$url->getLastMod()->format('c').'</lastmod>'.PHP_EOL.
+            '  <loc>'.htmlspecialchars($url->getLocation()).'</loc>'.PHP_EOL.
+            '  <lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.PHP_EOL.
             '  <changefreq>'.$url->getChangeFreq().'</changefreq>'.PHP_EOL.
             '  <priority>'.$url->getPriority().'</priority>'.PHP_EOL.
             ' </url>'.PHP_EOL.
@@ -174,14 +174,14 @@ class XMLWriterSitemapRenderTest extends TestCase
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.
             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL.
                 '<url>'.
-                    '<loc>'.htmlspecialchars($url1->getLoc()).'</loc>'.
-                    '<lastmod>'.$url1->getLastMod()->format('c').'</lastmod>'.
+                    '<loc>'.htmlspecialchars($url1->getLocation()).'</loc>'.
+                    '<lastmod>'.$url1->getLastModify()->format('c').'</lastmod>'.
                     '<changefreq>'.$url1->getChangeFreq().'</changefreq>'.
                     '<priority>'.$url1->getPriority().'</priority>'.
                 '</url>'.
                 '<url>'.
-                    '<loc>'.htmlspecialchars($url2->getLoc()).'</loc>'.
-                    '<lastmod>'.$url2->getLastMod()->format('c').'</lastmod>'.
+                    '<loc>'.htmlspecialchars($url2->getLocation()).'</loc>'.
+                    '<lastmod>'.$url2->getLastModify()->format('c').'</lastmod>'.
                     '<changefreq>'.$url2->getChangeFreq().'</changefreq>'.
                     '<priority>'.$url2->getPriority().'</priority>'.
                 '</url>'.
@@ -216,14 +216,14 @@ class XMLWriterSitemapRenderTest extends TestCase
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.
             '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL.
             ' <url>'.PHP_EOL.
-            '  <loc>'.htmlspecialchars($url1->getLoc()).'</loc>'.PHP_EOL.
-            '  <lastmod>'.$url1->getLastMod()->format('c').'</lastmod>'.PHP_EOL.
+            '  <loc>'.htmlspecialchars($url1->getLocation()).'</loc>'.PHP_EOL.
+            '  <lastmod>'.$url1->getLastModify()->format('c').'</lastmod>'.PHP_EOL.
             '  <changefreq>'.$url1->getChangeFreq().'</changefreq>'.PHP_EOL.
             '  <priority>'.$url1->getPriority().'</priority>'.PHP_EOL.
             ' </url>'.PHP_EOL.
             ' <url>'.PHP_EOL.
-            '  <loc>'.htmlspecialchars($url2->getLoc()).'</loc>'.PHP_EOL.
-            '  <lastmod>'.$url2->getLastMod()->format('c').'</lastmod>'.PHP_EOL.
+            '  <loc>'.htmlspecialchars($url2->getLocation()).'</loc>'.PHP_EOL.
+            '  <lastmod>'.$url2->getLastModify()->format('c').'</lastmod>'.PHP_EOL.
             '  <changefreq>'.$url2->getChangeFreq().'</changefreq>'.PHP_EOL.
             '  <priority>'.$url2->getPriority().'</priority>'.PHP_EOL.
             ' </url>'.PHP_EOL.

--- a/tests/Stream/CallbackStreamTest.php
+++ b/tests/Stream/CallbackStreamTest.php
@@ -46,7 +46,7 @@ class CallbackStreamTest extends TestCase
     {
         $this->render = $this->createMock(SitemapRender::class);
         $call = 0;
-        $this->stream = new CallbackStream($this->render, function ($content) use (&$call) {
+        $this->stream = new CallbackStream($this->render, static function ($content) use (&$call) {
             if ($call === 0) {
                 self::assertEquals(self::OPENED, $content);
             } else {
@@ -118,7 +118,7 @@ class CallbackStreamTest extends TestCase
         ];
 
         $call = 0;
-        $this->stream = new CallbackStream($this->render, function ($content) use (&$call, $urls) {
+        $this->stream = new CallbackStream($this->render, static function ($content) use (&$call, $urls) {
             if ($call === 0) {
                 self::assertEquals(self::OPENED, $content);
             } elseif (isset($urls[$call - 1])) {
@@ -133,7 +133,7 @@ class CallbackStreamTest extends TestCase
         $this->render
             ->expects(self::at($render_call++))
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         foreach ($urls as $i => $url) {
             /* @var $url Url */
@@ -141,14 +141,14 @@ class CallbackStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($url)
-                ->will(self::returnValue($url->getLocation()))
+                ->willReturn($url->getLocation())
             ;
             // render end string after first url
             if ($i === 0) {
                 $this->render
                     ->expects(self::at($render_call++))
                     ->method('end')
-                    ->will(self::returnValue(self::CLOSED))
+                    ->willReturn(self::CLOSED)
                 ;
             }
         }
@@ -164,7 +164,7 @@ class CallbackStreamTest extends TestCase
     {
         $loc = '/';
         $call = 0;
-        $this->stream = new CallbackStream($this->render, function ($content) use (&$call, $loc) {
+        $this->stream = new CallbackStream($this->render, static function ($content) use (&$call, $loc) {
             if ($call === 0) {
                 self::assertEquals(self::OPENED, $content);
             } elseif ($call - 1 < CallbackStream::LINKS_LIMIT) {
@@ -178,7 +178,7 @@ class CallbackStreamTest extends TestCase
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         $this->open();
@@ -205,17 +205,17 @@ class CallbackStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue($opened))
+            ->willReturn($opened)
         ;
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
         $call = 0;
         $this->stream = new CallbackStream(
             $this->render,
-            function ($content) use (&$call, $loc, &$i, $loops, $opened) {
+            static function ($content) use (&$call, $loc, &$i, $loops, $opened) {
                 if ($call === 0) {
                     self::assertEquals($opened, $content);
                 } elseif ($i + 1 < $loops) {
@@ -242,7 +242,7 @@ class CallbackStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         $this->stream->open();
     }
@@ -252,7 +252,7 @@ class CallbackStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('end')
-            ->will(self::returnValue(self::CLOSED))
+            ->willReturn(self::CLOSED)
         ;
         $this->stream->close();
     }

--- a/tests/Stream/CallbackStreamTest.php
+++ b/tests/Stream/CallbackStreamTest.php
@@ -122,7 +122,7 @@ class CallbackStreamTest extends TestCase
             if ($call === 0) {
                 self::assertEquals(self::OPENED, $content);
             } elseif (isset($urls[$call - 1])) {
-                self::assertEquals($urls[$call - 1]->getLoc(), $content);
+                self::assertEquals($urls[$call - 1]->getLocation(), $content);
             } else {
                 self::assertEquals(self::CLOSED, $content);
             }
@@ -141,7 +141,7 @@ class CallbackStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($url)
-                ->will(self::returnValue($url->getLoc()))
+                ->will(self::returnValue($url->getLocation()))
             ;
             // render end string after first url
             if ($i === 0) {

--- a/tests/Stream/LoggerStreamTest.php
+++ b/tests/Stream/LoggerStreamTest.php
@@ -49,18 +49,18 @@ class LoggerStreamTest extends TestCase
         $this->logger
             ->expects(self::at(0))
             ->method('debug')
-            ->with(sprintf('URL "%s" was added to sitemap.xml', $url1->getLoc()), [
+            ->with(sprintf('URL "%s" was added to sitemap.xml', $url1->getLocation()), [
                 'changefreq' => $url1->getChangeFreq(),
-                'lastmod' => $url1->getLastMod(),
+                'lastmod' => $url1->getLastModify(),
                 'priority' => $url1->getPriority(),
             ])
         ;
         $this->logger
             ->expects(self::at(1))
             ->method('debug')
-            ->with(sprintf('URL "%s" was added to sitemap.xml', $url2->getLoc()), [
+            ->with(sprintf('URL "%s" was added to sitemap.xml', $url2->getLocation()), [
                 'changefreq' => $url2->getChangeFreq(),
-                'lastmod' => $url2->getLastMod(),
+                'lastmod' => $url2->getLastModify(),
                 'priority' => $url2->getPriority(),
             ])
         ;

--- a/tests/Stream/MultiStreamTest.php
+++ b/tests/Stream/MultiStreamTest.php
@@ -55,9 +55,9 @@ class MultiStreamTest extends TestCase
             $substream
                 ->expects(self::once())
                 ->method('open')
-                ->will(self::returnCallback(function () use (&$i) {
+                ->willReturnCallback(static function () use (&$i) {
                     ++$i;
-                }))
+                })
             ;
         }
 
@@ -80,9 +80,9 @@ class MultiStreamTest extends TestCase
             $substream
                 ->expects(self::once())
                 ->method('close')
-                ->will(self::returnCallback(function () use (&$i) {
+                ->willReturnCallback(static function () use (&$i) {
                     ++$i;
-                }))
+                })
             ;
         }
 
@@ -113,9 +113,9 @@ class MultiStreamTest extends TestCase
                     ->expects(self::at($j))
                     ->method('push')
                     ->with($url)
-                    ->will(self::returnCallback(function () use (&$i) {
+                    ->willReturnCallback(static function () use (&$i) {
                         ++$i;
-                    }))
+                    })
                 ;
             }
         }
@@ -143,9 +143,9 @@ class MultiStreamTest extends TestCase
                 ->expects(self::at(0))
                 ->method('push')
                 ->with($url)
-                ->will(self::returnCallback(function () use (&$i) {
+                ->willReturnCallback(static function () use (&$i) {
                     ++$i;
-                }))
+                })
             ;
         }
         $stream->push($url);

--- a/tests/Stream/OutputStreamTest.php
+++ b/tests/Stream/OutputStreamTest.php
@@ -128,7 +128,7 @@ class OutputStreamTest extends TestCase
         $this->render
             ->expects(self::at($render_call++))
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         foreach ($urls as $i => $url) {
             /* @var $url Url */
@@ -136,14 +136,14 @@ class OutputStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLocation()))
+                ->willReturn($url->getLocation())
             ;
             // render end string after first url
             if ($i === 0) {
                 $this->render
                     ->expects(self::at($render_call++))
                     ->method('end')
-                    ->will(self::returnValue(self::CLOSED))
+                    ->willReturn(self::CLOSED)
                 ;
             }
             $this->expected_buffer .= $url->getLocation();
@@ -165,7 +165,7 @@ class OutputStreamTest extends TestCase
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         try {
@@ -190,12 +190,12 @@ class OutputStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue(str_repeat('/', $prefix_size)))
+            ->willReturn(str_repeat('/', $prefix_size))
         ;
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         $this->stream->open();
@@ -216,7 +216,7 @@ class OutputStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         $this->stream->open();
         $this->expected_buffer .= self::OPENED;
@@ -227,7 +227,7 @@ class OutputStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('end')
-            ->will(self::returnValue(self::CLOSED))
+            ->willReturn(self::CLOSED)
         ;
         $this->stream->close();
         $this->expected_buffer .= self::CLOSED;

--- a/tests/Stream/OutputStreamTest.php
+++ b/tests/Stream/OutputStreamTest.php
@@ -136,7 +136,7 @@ class OutputStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLoc()))
+                ->will(self::returnValue($url->getLocation()))
             ;
             // render end string after first url
             if ($i === 0) {
@@ -146,7 +146,7 @@ class OutputStreamTest extends TestCase
                     ->will(self::returnValue(self::CLOSED))
                 ;
             }
-            $this->expected_buffer .= $url->getLoc();
+            $this->expected_buffer .= $url->getLocation();
         }
         $this->expected_buffer .= self::CLOSED;
 

--- a/tests/Stream/RenderFileStreamTest.php
+++ b/tests/Stream/RenderFileStreamTest.php
@@ -145,7 +145,7 @@ class RenderFileStreamTest extends TestCase
         $this->render
             ->expects(self::at($render_call++))
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         foreach ($urls as $i => $url) {
             /* @var $url Url */
@@ -153,14 +153,14 @@ class RenderFileStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLocation()))
+                ->willReturn($url->getLocation())
             ;
             // render end string after first url
             if ($i === 0) {
                 $this->render
                     ->expects(self::at($render_call++))
                     ->method('end')
-                    ->will(self::returnValue(self::CLOSED))
+                    ->willReturn(self::CLOSED)
                 ;
             }
             $this->expected_content .= $url->getLocation();
@@ -182,7 +182,7 @@ class RenderFileStreamTest extends TestCase
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         for ($i = 0; $i <= RenderFileStream::LINKS_LIMIT; ++$i) {
@@ -202,12 +202,12 @@ class RenderFileStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue(str_repeat('/', $prefix_size)))
+            ->willReturn(str_repeat('/', $prefix_size))
         ;
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         $this->stream->open();
@@ -222,7 +222,7 @@ class RenderFileStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
 
         $this->stream->open();
@@ -234,7 +234,7 @@ class RenderFileStreamTest extends TestCase
         $this->render
             ->expects(self::once())
             ->method('end')
-            ->will(self::returnValue(self::CLOSED))
+            ->willReturn(self::CLOSED)
         ;
         $this->stream->close();
         $this->expected_content .= self::CLOSED;

--- a/tests/Stream/RenderFileStreamTest.php
+++ b/tests/Stream/RenderFileStreamTest.php
@@ -153,7 +153,7 @@ class RenderFileStreamTest extends TestCase
                 ->expects(self::at($render_call++))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLoc()))
+                ->will(self::returnValue($url->getLocation()))
             ;
             // render end string after first url
             if ($i === 0) {
@@ -163,7 +163,7 @@ class RenderFileStreamTest extends TestCase
                     ->will(self::returnValue(self::CLOSED))
                 ;
             }
-            $this->expected_content .= $url->getLoc();
+            $this->expected_content .= $url->getLocation();
         }
         $this->expected_content .= self::CLOSED;
 

--- a/tests/Stream/RenderGzipFileStreamTest.php
+++ b/tests/Stream/RenderGzipFileStreamTest.php
@@ -148,7 +148,7 @@ class RenderGzipFileStreamTest extends TestCase
                 ->expects(self::at($i))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLocation()))
+                ->willReturn($url->getLocation())
             ;
             $this->expected_content .= $url->getLocation();
         }
@@ -191,7 +191,7 @@ class RenderGzipFileStreamTest extends TestCase
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         for ($i = 0; $i <= RenderGzipFileStream::LINKS_LIMIT; ++$i) {
@@ -211,12 +211,12 @@ class RenderGzipFileStreamTest extends TestCase
         $this->render
             ->expects(self::at(0))
             ->method('start')
-            ->will(self::returnValue(str_repeat('/', $prefix_size)))
+            ->willReturn(str_repeat('/', $prefix_size))
         ;
         $this->render
             ->expects(self::atLeastOnce())
             ->method('url')
-            ->will(self::returnValue($loc))
+            ->willReturn($loc)
         ;
 
         $this->stream->open();
@@ -231,12 +231,12 @@ class RenderGzipFileStreamTest extends TestCase
         $this->render
             ->expects(self::at(0))
             ->method('start')
-            ->will(self::returnValue(self::OPENED))
+            ->willReturn(self::OPENED)
         ;
         $this->render
             ->expects(self::at(1))
             ->method('end')
-            ->will(self::returnValue(self::CLOSED))
+            ->willReturn(self::CLOSED)
         ;
 
         $this->stream->open();

--- a/tests/Stream/RenderGzipFileStreamTest.php
+++ b/tests/Stream/RenderGzipFileStreamTest.php
@@ -148,9 +148,9 @@ class RenderGzipFileStreamTest extends TestCase
                 ->expects(self::at($i))
                 ->method('url')
                 ->with($urls[$i])
-                ->will(self::returnValue($url->getLoc()))
+                ->will(self::returnValue($url->getLocation()))
             ;
-            $this->expected_content .= $url->getLoc();
+            $this->expected_content .= $url->getLocation();
         }
 
         foreach ($urls as $url) {

--- a/tests/Stream/RenderIndexFileStreamTest.php
+++ b/tests/Stream/RenderIndexFileStreamTest.php
@@ -198,7 +198,7 @@ class RenderIndexFileStreamTest extends TestCase
 
     public function testOverflow(): void
     {
-        $this->initStream('sitemap.xml');
+        $this->initStream();
         $this->stream->open();
         for ($i = 0; $i <= RenderFileStream::LINKS_LIMIT; ++$i) {
             $this->stream->push(new Url('/'));

--- a/tests/Url/ChangeFreqTest.php
+++ b/tests/Url/ChangeFreqTest.php
@@ -36,12 +36,12 @@ class ChangeFreqTest extends TestCase
     /**
      * @dataProvider changeFreqOfLastMod
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
      */
-    public function testGetChangeFreqByLastMod(\DateTimeInterface $last_mod, ?string $change_freq): void
+    public function testGetChangeFreqByLastMod(\DateTimeInterface $last_modify, ?string $change_freq): void
     {
-        self::assertEquals($change_freq, ChangeFreq::getByLastMod($last_mod));
+        self::assertEquals($change_freq, ChangeFreq::getByLastMod($last_modify));
     }
 
     /**

--- a/tests/Url/ChangeFreqTest.php
+++ b/tests/Url/ChangeFreqTest.php
@@ -19,7 +19,7 @@ class ChangeFreqTest extends TestCase
     /**
      * @return array
      */
-    public function changeFreqOfLastMod(): array
+    public function getChangeFreqOfLastModify(): array
     {
         return [
             [new \DateTimeImmutable('-1 year -1 day'), ChangeFreq::YEARLY],
@@ -34,20 +34,20 @@ class ChangeFreqTest extends TestCase
     }
 
     /**
-     * @dataProvider changeFreqOfLastMod
+     * @dataProvider getChangeFreqOfLastModify
      *
      * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
      */
-    public function testGetChangeFreqByLastMod(\DateTimeInterface $last_modify, ?string $change_freq): void
+    public function testGetChangeFreqByLastModify(\DateTimeInterface $last_modify, ?string $change_freq): void
     {
-        self::assertEquals($change_freq, ChangeFreq::getByLastMod($last_modify));
+        self::assertEquals($change_freq, ChangeFreq::getByLastModify($last_modify));
     }
 
     /**
      * @return array
      */
-    public function changeFreqOfPriority(): array
+    public function getChangeFreqOfPriority(): array
     {
         return [
             ['1.0', ChangeFreq::HOURLY],
@@ -66,7 +66,7 @@ class ChangeFreqTest extends TestCase
     }
 
     /**
-     * @dataProvider changeFreqOfPriority
+     * @dataProvider getChangeFreqOfPriority
      *
      * @param string $priority
      * @param string $change_freq

--- a/tests/Url/PriorityTest.php
+++ b/tests/Url/PriorityTest.php
@@ -19,7 +19,7 @@ class PriorityTest extends TestCase
     /**
      * @return array
      */
-    public function priorityOfLocations(): array
+    public function getPriorityOfLocations(): array
     {
         return [
             ['/', '1.0'],
@@ -39,13 +39,13 @@ class PriorityTest extends TestCase
     }
 
     /**
-     * @dataProvider priorityOfLocations
+     * @dataProvider getPriorityOfLocations
      *
      * @param string $location
      * @param string $priority
      */
-    public function testGetPriorityByLoc(string $location, string $priority): void
+    public function testGetPriorityByLocation(string $location, string $priority): void
     {
-        self::assertEquals($priority, Priority::getByLoc($location));
+        self::assertEquals($priority, Priority::getByLocation($location));
     }
 }

--- a/tests/Url/PriorityTest.php
+++ b/tests/Url/PriorityTest.php
@@ -41,11 +41,11 @@ class PriorityTest extends TestCase
     /**
      * @dataProvider priorityOfLocations
      *
-     * @param string $loc
+     * @param string $location
      * @param string $priority
      */
-    public function testGetPriorityByLoc(string $loc, string $priority): void
+    public function testGetPriorityByLoc(string $location, string $priority): void
     {
-        self::assertEquals($priority, Priority::getByLoc($loc));
+        self::assertEquals($priority, Priority::getByLoc($location));
     }
 }

--- a/tests/Url/SmartUrlTest.php
+++ b/tests/Url/SmartUrlTest.php
@@ -22,8 +22,8 @@ class SmartUrlTest extends TestCase
         $location = '';
         $url = new SmartUrl($location);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
         self::assertEquals(ChangeFreq::HOURLY, $url->getChangeFreq());
         self::assertEquals(SmartUrl::DEFAULT_PRIORITY, $url->getPriority());
     }
@@ -31,7 +31,7 @@ class SmartUrlTest extends TestCase
     /**
      * @return array
      */
-    public function urls(): array
+    public function getUrls(): array
     {
         return [
             [new \DateTimeImmutable('-10 minutes'), ChangeFreq::ALWAYS, '1.0'],
@@ -52,7 +52,7 @@ class SmartUrlTest extends TestCase
     }
 
     /**
-     * @dataProvider urls
+     * @dataProvider getUrls
      *
      * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
@@ -64,8 +64,8 @@ class SmartUrlTest extends TestCase
 
         $url = new SmartUrl($location, $last_modify, $change_freq, $priority);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertEquals($last_modify, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertEquals($last_modify, $url->getLastModify());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }
@@ -73,7 +73,7 @@ class SmartUrlTest extends TestCase
     /**
      * @return array
      */
-    public function priorityOfLocations(): array
+    public function getPriorityOfLocations(): array
     {
         return [
             ['/', '1.0'],
@@ -93,7 +93,7 @@ class SmartUrlTest extends TestCase
     }
 
     /**
-     * @dataProvider priorityOfLocations
+     * @dataProvider getPriorityOfLocations
      *
      * @param string $location
      * @param string $priority
@@ -102,14 +102,14 @@ class SmartUrlTest extends TestCase
     {
         $url = new SmartUrl($location);
 
-        self::assertEquals($location, $url->getLoc());
+        self::assertEquals($location, $url->getLocation());
         self::assertEquals($priority, $url->getPriority());
     }
 
     /**
      * @return array
      */
-    public function changeFreqOfLastMod(): array
+    public function getChangeFreqOfLastModify(): array
     {
         return [
             [new \DateTimeImmutable('-1 year -1 day'), ChangeFreq::YEARLY],
@@ -124,7 +124,7 @@ class SmartUrlTest extends TestCase
     }
 
     /**
-     * @dataProvider changeFreqOfLastMod
+     * @dataProvider getChangeFreqOfLastModify
      *
      * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
@@ -134,15 +134,15 @@ class SmartUrlTest extends TestCase
         $location = '/';
         $url = new SmartUrl($location, $last_modify);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertEquals($last_modify, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertEquals($last_modify, $url->getLastModify());
         self::assertEquals($change_freq, $url->getChangeFreq());
     }
 
     /**
      * @return array
      */
-    public function changeFreqOfPriority(): array
+    public function getChangeFreqOfPriority(): array
     {
         return [
             ['1.0', ChangeFreq::HOURLY],
@@ -161,7 +161,7 @@ class SmartUrlTest extends TestCase
     }
 
     /**
-     * @dataProvider changeFreqOfPriority
+     * @dataProvider getChangeFreqOfPriority
      *
      * @param string $priority
      * @param string $change_freq
@@ -171,8 +171,8 @@ class SmartUrlTest extends TestCase
         $location = '/';
         $url = new SmartUrl($location, null, null, $priority);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }

--- a/tests/Url/SmartUrlTest.php
+++ b/tests/Url/SmartUrlTest.php
@@ -19,10 +19,10 @@ class SmartUrlTest extends TestCase
 {
     public function testDefaultUrl(): void
     {
-        $loc = '';
-        $url = new SmartUrl($loc);
+        $location = '';
+        $url = new SmartUrl($location);
 
-        self::assertEquals($loc, $url->getLoc());
+        self::assertEquals($location, $url->getLoc());
         self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
         self::assertEquals(ChangeFreq::HOURLY, $url->getChangeFreq());
         self::assertEquals(SmartUrl::DEFAULT_PRIORITY, $url->getPriority());
@@ -54,18 +54,18 @@ class SmartUrlTest extends TestCase
     /**
      * @dataProvider urls
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
      * @param string             $priority
      */
-    public function testCustomUrl(\DateTimeInterface $last_mod, string $change_freq, string $priority): void
+    public function testCustomUrl(\DateTimeInterface $last_modify, string $change_freq, string $priority): void
     {
-        $loc = '/';
+        $location = '/';
 
-        $url = new SmartUrl($loc, $last_mod, $change_freq, $priority);
+        $url = new SmartUrl($location, $last_modify, $change_freq, $priority);
 
-        self::assertEquals($loc, $url->getLoc());
-        self::assertEquals($last_mod, $url->getLastMod());
+        self::assertEquals($location, $url->getLoc());
+        self::assertEquals($last_modify, $url->getLastMod());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }
@@ -95,14 +95,14 @@ class SmartUrlTest extends TestCase
     /**
      * @dataProvider priorityOfLocations
      *
-     * @param string $loc
+     * @param string $location
      * @param string $priority
      */
-    public function testSmartPriority(string $loc, string $priority): void
+    public function testSmartPriority(string $location, string $priority): void
     {
-        $url = new SmartUrl($loc);
+        $url = new SmartUrl($location);
 
-        self::assertEquals($loc, $url->getLoc());
+        self::assertEquals($location, $url->getLoc());
         self::assertEquals($priority, $url->getPriority());
     }
 
@@ -126,16 +126,16 @@ class SmartUrlTest extends TestCase
     /**
      * @dataProvider changeFreqOfLastMod
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
      */
-    public function testSmartChangeFreqFromLastMod(\DateTimeInterface $last_mod, string $change_freq): void
+    public function testSmartChangeFreqFromLastMod(\DateTimeInterface $last_modify, string $change_freq): void
     {
-        $loc = '/';
-        $url = new SmartUrl($loc, $last_mod);
+        $location = '/';
+        $url = new SmartUrl($location, $last_modify);
 
-        self::assertEquals($loc, $url->getLoc());
-        self::assertEquals($last_mod, $url->getLastMod());
+        self::assertEquals($location, $url->getLoc());
+        self::assertEquals($last_modify, $url->getLastMod());
         self::assertEquals($change_freq, $url->getChangeFreq());
     }
 
@@ -168,10 +168,10 @@ class SmartUrlTest extends TestCase
      */
     public function testSmartChangeFreqFromPriority(string $priority, string $change_freq): void
     {
-        $loc = '/';
-        $url = new SmartUrl($loc, null, null, $priority);
+        $location = '/';
+        $url = new SmartUrl($location, null, null, $priority);
 
-        self::assertEquals($loc, $url->getLoc());
+        self::assertEquals($location, $url->getLoc());
         self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -19,10 +19,10 @@ class UrlTest extends TestCase
 {
     public function testDefaultUrl(): void
     {
-        $loc = '';
-        $url = new Url($loc);
+        $location = '';
+        $url = new Url($location);
 
-        self::assertEquals($loc, $url->getLoc());
+        self::assertEquals($location, $url->getLoc());
         self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
         self::assertEquals(Url::DEFAULT_CHANGE_FREQ, $url->getChangeFreq());
         self::assertEquals(Url::DEFAULT_PRIORITY, $url->getPriority());
@@ -54,18 +54,18 @@ class UrlTest extends TestCase
     /**
      * @dataProvider urls
      *
-     * @param \DateTimeInterface $last_mod
+     * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
      * @param string             $priority
      */
-    public function testCustomUrl(\DateTimeInterface $last_mod, string $change_freq, string $priority): void
+    public function testCustomUrl(\DateTimeInterface $last_modify, string $change_freq, string $priority): void
     {
-        $loc = '/index.html';
+        $location = '/index.html';
 
-        $url = new Url($loc, $last_mod, $change_freq, $priority);
+        $url = new Url($location, $last_modify, $change_freq, $priority);
 
-        self::assertEquals($loc, $url->getLoc());
-        self::assertEquals($last_mod, $url->getLastMod());
+        self::assertEquals($location, $url->getLoc());
+        self::assertEquals($last_modify, $url->getLastMod());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -22,8 +22,8 @@ class UrlTest extends TestCase
         $location = '';
         $url = new Url($location);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
         self::assertEquals(Url::DEFAULT_CHANGE_FREQ, $url->getChangeFreq());
         self::assertEquals(Url::DEFAULT_PRIORITY, $url->getPriority());
     }
@@ -31,7 +31,7 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function urls(): array
+    public function getUrls(): array
     {
         return [
             [new \DateTimeImmutable('-10 minutes'), ChangeFreq::ALWAYS, '1.0'],
@@ -52,7 +52,7 @@ class UrlTest extends TestCase
     }
 
     /**
-     * @dataProvider urls
+     * @dataProvider getUrls
      *
      * @param \DateTimeInterface $last_modify
      * @param string             $change_freq
@@ -64,8 +64,8 @@ class UrlTest extends TestCase
 
         $url = new Url($location, $last_modify, $change_freq, $priority);
 
-        self::assertEquals($location, $url->getLoc());
-        self::assertEquals($last_modify, $url->getLastMod());
+        self::assertEquals($location, $url->getLocation());
+        self::assertEquals($last_modify, $url->getLastModify());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }


### PR DESCRIPTION
* Rename method `Url::getLoc()` to `Url::getLocation()`.
* Rename method `Url::getLastMod()` to `Url::getLastModify()`.
* Rename variable `$last_mod` to `$last_modify`.
* Rename variable `$loc` to `$location`.

This is more informative.