### PR TITLE
The lastmod, changefreq and priority fields is not required

### DIFF
--- a/src/Render/PlainTextSitemapRender.php
+++ b/src/Render/PlainTextSitemapRender.php
@@ -69,11 +69,21 @@ class PlainTextSitemapRender implements SitemapRender
      */
     public function url(Url $url): string
     {
-        return '<url>'.
-            '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>'.
-            '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
-            '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
-            '<priority>'.$url->getPriority().'</priority>'.
-        '</url>';
+        $result = '<url>';
+        $result .= '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>';
+
+        if ($url->getLastModify() instanceof \DateTimeInterface) {
+            $result .= '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>';
+        }
+        if ($url->getChangeFreq() !== null) {
+            $result .= '<changefreq>'.$url->getChangeFreq().'</changefreq>';
+        }
+        if ($url->getPriority() !== null) {
+            $result .= '<priority>'.$url->getPriority().'</priority>';
+        }
+
+        $result .= '</url>';
+
+        return $result;
     }
 }

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -113,9 +113,15 @@ class XMLWriterSitemapRender implements SitemapRender
 
         $this->writer->startElement('url');
         $this->writer->writeElement('loc', $this->web_path.$url->getLocation());
-        $this->writer->writeElement('lastmod', $url->getLastModify()->format('c'));
-        $this->writer->writeElement('changefreq', $url->getChangeFreq());
-        $this->writer->writeElement('priority', $url->getPriority());
+        if ($url->getLastModify() instanceof \DateTimeInterface) {
+            $this->writer->writeElement('lastmod', $url->getLastModify()->format('c'));
+        }
+        if ($url->getChangeFreq() !== null) {
+            $this->writer->writeElement('changefreq', $url->getChangeFreq());
+        }
+        if ($url->getPriority() !== null) {
+            $this->writer->writeElement('priority', $url->getPriority());
+        }
         $this->writer->endElement();
 
         return $this->writer->flush();

--- a/src/Url/SmartUrl.php
+++ b/src/Url/SmartUrl.php
@@ -26,17 +26,17 @@ class SmartUrl extends Url
         ?string $priority = null
     ) {
         // priority from loc
-        if (!$priority) {
+        if ($priority === null) {
             $priority = Priority::getByLocation($location);
         }
 
         // change freq from last mod
-        if (!$change_freq && $last_modify instanceof \DateTimeInterface) {
+        if ($change_freq === null && $last_modify instanceof \DateTimeInterface) {
             $change_freq = ChangeFreq::getByLastModify($last_modify);
         }
 
         // change freq from priority
-        if (!$change_freq) {
+        if ($change_freq === null) {
             $change_freq = ChangeFreq::getByPriority($priority);
         }
 

--- a/src/Url/Url.php
+++ b/src/Url/Url.php
@@ -13,27 +13,23 @@ namespace GpsLab\Component\Sitemap\Url;
 
 class Url
 {
-    public const DEFAULT_PRIORITY = '1.0';
-
-    public const DEFAULT_CHANGE_FREQ = ChangeFreq::WEEKLY;
-
     /**
      * @var string
      */
     private $location;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      */
     private $last_modify;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $change_freq;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $priority;
 
@@ -50,9 +46,9 @@ class Url
         ?string $priority = null
     ) {
         $this->location = $location;
-        $this->last_modify = $last_modify ?: new \DateTimeImmutable();
-        $this->change_freq = $change_freq ?: self::DEFAULT_CHANGE_FREQ;
-        $this->priority = $priority ?: self::DEFAULT_PRIORITY;
+        $this->last_modify = $last_modify;
+        $this->change_freq = $change_freq;
+        $this->priority = $priority;
     }
 
     /**
@@ -64,25 +60,25 @@ class Url
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
-    public function getLastModify(): \DateTimeInterface
+    public function getLastModify(): ?\DateTimeInterface
     {
         return $this->last_modify;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getChangeFreq(): string
+    public function getChangeFreq(): ?string
     {
         return $this->change_freq;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPriority(): string
+    public function getPriority(): ?string
     {
         return $this->priority;
     }

--- a/tests/Render/PlainTextSitemapRenderTest.php
+++ b/tests/Render/PlainTextSitemapRenderTest.php
@@ -76,22 +76,42 @@ class PlainTextSitemapRenderTest extends TestCase
         self::assertEquals($expected, $this->render->end());
     }
 
-    public function testUrl(): void
+    /**
+     * @return array
+     */
+    public function getUrls(): array
     {
-        $url = new Url(
-            '/',
-            new \DateTimeImmutable('-1 day'),
-            ChangeFreq::WEEKLY,
-            '1.0'
-        );
+        return [
+            [new Url('/')],
+            [new Url('/', new \DateTimeImmutable('-1 day'))],
+            [new Url('/', null, ChangeFreq::WEEKLY)],
+            [new Url('/', null, null, '1.0')],
+            [new Url('/', null, ChangeFreq::WEEKLY, '1.0')],
+            [new Url('/', new \DateTimeImmutable('-1 day'), null, '1.0')],
+            [new Url('/', new \DateTimeImmutable('-1 day'), ChangeFreq::WEEKLY, null)],
+            [new Url('/', new \DateTimeImmutable('-1 day'), ChangeFreq::WEEKLY, '1.0')],
+        ];
+    }
 
-        $expected = '<url>'.
-            '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>'.
-            '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
-            '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
-            '<priority>'.$url->getPriority().'</priority>'.
-            '</url>'
-        ;
+    /**
+     * @dataProvider getUrls
+     *
+     * @param Url $url
+     */
+    public function testUrl(Url $url): void
+    {
+        $expected = '<url>';
+        $expected .= '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>';
+        if ($url->getLastModify()) {
+            $expected .= '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>';
+        }
+        if ($url->getChangeFreq()) {
+            $expected .= '<changefreq>'.$url->getChangeFreq().'</changefreq>';
+        }
+        if ($url->getPriority()) {
+            $expected .= '<priority>'.$url->getPriority().'</priority>';
+        }
+        $expected .= '</url>';
 
         self::assertEquals($expected, $this->render->url($url));
     }

--- a/tests/Render/XMLWriterSitemapRenderTest.php
+++ b/tests/Render/XMLWriterSitemapRenderTest.php
@@ -146,7 +146,6 @@ class XMLWriterSitemapRenderTest extends TestCase
         self::assertEquals($expected, $this->render->url($url));
     }
 
-
     /**
      * @dataProvider getUrls
      *

--- a/tests/Render/XMLWriterSitemapRenderTest.php
+++ b/tests/Render/XMLWriterSitemapRenderTest.php
@@ -106,45 +106,68 @@ class XMLWriterSitemapRenderTest extends TestCase
         self::assertEquals($expected, $render->start().$render->end());
     }
 
-    public function testAddUrlInNotStarted(): void
+    /**
+     * @return array
+     */
+    public function getUrls(): array
     {
-        $url = new Url(
-            '/',
-            new \DateTimeImmutable('-1 day'),
-            ChangeFreq::YEARLY,
-            '0.1'
-        );
+        return [
+            [new Url('/')],
+            [new Url('/', new \DateTimeImmutable('-1 day'))],
+            [new Url('/', null, ChangeFreq::WEEKLY)],
+            [new Url('/', null, null, '1.0')],
+            [new Url('/', null, ChangeFreq::WEEKLY, '1.0')],
+            [new Url('/', new \DateTimeImmutable('-1 day'), null, '1.0')],
+            [new Url('/', new \DateTimeImmutable('-1 day'), ChangeFreq::WEEKLY, null)],
+            [new Url('/', new \DateTimeImmutable('-1 day'), ChangeFreq::WEEKLY, '1.0')],
+        ];
+    }
 
-        $expected =
-            '<url>'.
-                '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>'.
-                '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.
-                '<changefreq>'.$url->getChangeFreq().'</changefreq>'.
-                '<priority>'.$url->getPriority().'</priority>'.
-            '</url>'
-        ;
+    /**
+     * @dataProvider getUrls
+     *
+     * @param Url $url
+     */
+    public function testAddUrlInNotStarted(Url $url): void
+    {
+        $expected = '<url>';
+        $expected .= '<loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>';
+        if ($url->getLastModify()) {
+            $expected .= '<lastmod>'.$url->getLastModify()->format('c').'</lastmod>';
+        }
+        if ($url->getChangeFreq()) {
+            $expected .= '<changefreq>'.$url->getChangeFreq().'</changefreq>';
+        }
+        if ($url->getPriority()) {
+            $expected .= '<priority>'.$url->getPriority().'</priority>';
+        }
+        $expected .= '</url>';
 
         self::assertEquals($expected, $this->render->url($url));
     }
 
-    public function testAddUrlInNotStartedUseIndent(): void
+
+    /**
+     * @dataProvider getUrls
+     *
+     * @param Url $url
+     */
+    public function testAddUrlInNotStartedUseIndent(Url $url): void
     {
         $render = new XMLWriterSitemapRender($this->web_path, false, true);
-        $url = new Url(
-            '/',
-            new \DateTimeImmutable('-1 day'),
-            ChangeFreq::YEARLY,
-            '0.1'
-        );
 
-        $expected =
-            ' <url>'.PHP_EOL.
-            '  <loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>'.PHP_EOL.
-            '  <lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.PHP_EOL.
-            '  <changefreq>'.$url->getChangeFreq().'</changefreq>'.PHP_EOL.
-            '  <priority>'.$url->getPriority().'</priority>'.PHP_EOL.
-            ' </url>'.PHP_EOL
-        ;
+        $expected = ' <url>'.PHP_EOL;
+        $expected .= '  <loc>'.htmlspecialchars($this->web_path.$url->getLocation()).'</loc>'.PHP_EOL;
+        if ($url->getLastModify()) {
+            $expected .= '  <lastmod>'.$url->getLastModify()->format('c').'</lastmod>'.PHP_EOL;
+        }
+        if ($url->getChangeFreq()) {
+            $expected .= '  <changefreq>'.$url->getChangeFreq().'</changefreq>'.PHP_EOL;
+        }
+        if ($url->getPriority()) {
+            $expected .= '  <priority>'.$url->getPriority().'</priority>'.PHP_EOL;
+        }
+        $expected .= ' </url>'.PHP_EOL;
 
         self::assertEquals($expected, $render->url($url));
     }
@@ -161,8 +184,8 @@ class XMLWriterSitemapRenderTest extends TestCase
         $url = new Url(
             '/',
             new \DateTimeImmutable('-1 day'),
-            ChangeFreq::YEARLY,
-            '0.1'
+            ChangeFreq::WEEKLY,
+            '1.0'
         );
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.
@@ -191,8 +214,8 @@ class XMLWriterSitemapRenderTest extends TestCase
         $url = new Url(
             '/',
             new \DateTimeImmutable('-1 day'),
-            ChangeFreq::YEARLY,
-            '0.1'
+            ChangeFreq::WEEKLY,
+            '1.0'
         );
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL.

--- a/tests/Url/SmartUrlTest.php
+++ b/tests/Url/SmartUrlTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Sitemap\Tests\Url;
 
 use GpsLab\Component\Sitemap\Url\ChangeFreq;
+use GpsLab\Component\Sitemap\Url\Priority;
 use GpsLab\Component\Sitemap\Url\SmartUrl;
 use PHPUnit\Framework\TestCase;
 
@@ -22,10 +23,13 @@ class SmartUrlTest extends TestCase
         $location = '';
         $url = new SmartUrl($location);
 
+        $priority = Priority::getByLocation($location);
+        $change_freq = ChangeFreq::getByPriority($priority);
+
         self::assertEquals($location, $url->getLocation());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
-        self::assertEquals(ChangeFreq::HOURLY, $url->getChangeFreq());
-        self::assertEquals(SmartUrl::DEFAULT_PRIORITY, $url->getPriority());
+        self::assertNull($url->getLastModify());
+        self::assertEquals($change_freq, $url->getChangeFreq());
+        self::assertEquals($priority, $url->getPriority());
     }
 
     /**
@@ -156,7 +160,6 @@ class SmartUrlTest extends TestCase
             ['0.2', ChangeFreq::YEARLY],
             ['0.1', ChangeFreq::YEARLY],
             ['0.0', ChangeFreq::NEVER],
-            ['-', SmartUrl::DEFAULT_CHANGE_FREQ],
         ];
     }
 
@@ -172,7 +175,7 @@ class SmartUrlTest extends TestCase
         $url = new SmartUrl($location, null, null, $priority);
 
         self::assertEquals($location, $url->getLocation());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
+        self::assertNull($url->getLastModify());
         self::assertEquals($change_freq, $url->getChangeFreq());
         self::assertEquals($priority, $url->getPriority());
     }

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -23,9 +23,9 @@ class UrlTest extends TestCase
         $url = new Url($location);
 
         self::assertEquals($location, $url->getLocation());
-        self::assertInstanceOf(\DateTimeImmutable::class, $url->getLastModify());
-        self::assertEquals(Url::DEFAULT_CHANGE_FREQ, $url->getChangeFreq());
-        self::assertEquals(Url::DEFAULT_PRIORITY, $url->getPriority());
+        self::assertNull($url->getLastModify());
+        self::assertNull($url->getChangeFreq());
+        self::assertNull($url->getPriority());
     }
 
     /**


### PR DESCRIPTION
Not set default value for arguments in URL class.
The `lastmod`, `changefreq` and `priority` is optional
fix #31