### PR TITLE
Correct return type in UrlBuilder::getIterator()

### DIFF
--- a/src/Builder/Url/UrlBuilder.php
+++ b/src/Builder/Url/UrlBuilder.php
@@ -19,7 +19,7 @@ interface UrlBuilder extends \Countable, \IteratorAggregate
     public function getName();
 
     /**
-     * @return Url[]
+     * @return \Traversable|Url[]
      */
     public function getIterator();
 }


### PR DESCRIPTION
fix #66