### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "psr/log": "~1.0",
         "gpslab/compressor": "~1.0",
         "symfony/console": "~2.4|~3.0|~4.0",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.5",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     }
 }

--- a/tests/Builder/Sitemap/SilentSitemapBuilderTest.php
+++ b/tests/Builder/Sitemap/SilentSitemapBuilderTest.php
@@ -14,8 +14,9 @@ use GpsLab\Component\Sitemap\Builder\Url\UrlBuilder;
 use GpsLab\Component\Sitemap\Builder\Url\UrlBuilderCollection;
 use GpsLab\Component\Sitemap\Stream\Stream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class SilentSitemapBuilderTest extends \PHPUnit_Framework_TestCase
+class SilentSitemapBuilderTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|UrlBuilderCollection

--- a/tests/Builder/Sitemap/SymfonySitemapBuilderTest.php
+++ b/tests/Builder/Sitemap/SymfonySitemapBuilderTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Sitemap\Builder\Url\UrlBuilderCollection;
 use GpsLab\Component\Sitemap\Stream\Stream;
 use GpsLab\Component\Sitemap\Url\Url;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use PHPUnit\Framework\TestCase;
 
-class SymfonySitemapBuilderTest extends \PHPUnit_Framework_TestCase
+class SymfonySitemapBuilderTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|UrlBuilderCollection

--- a/tests/Builder/Url/UrlBuilderCollectionTest.php
+++ b/tests/Builder/Url/UrlBuilderCollectionTest.php
@@ -11,8 +11,9 @@ namespace GpsLab\Component\Sitemap\Tests\Builder\Url;
 
 use GpsLab\Component\Sitemap\Builder\Url\UrlBuilder;
 use GpsLab\Component\Sitemap\Builder\Url\UrlBuilderCollection;
+use PHPUnit\Framework\TestCase;
 
-class UrlBuilderCollectionTest extends \PHPUnit_Framework_TestCase
+class UrlBuilderCollectionTest extends TestCase
 {
     public function testCollection()
     {

--- a/tests/Render/PlainTextSitemapIndexRenderTest.php
+++ b/tests/Render/PlainTextSitemapIndexRenderTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Render;
 
 use GpsLab\Component\Sitemap\Render\PlainTextSitemapIndexRender;
+use PHPUnit\Framework\TestCase;
 
-class PlainTextSitemapIndexRenderTest extends \PHPUnit_Framework_TestCase
+class PlainTextSitemapIndexRenderTest extends TestCase
 {
     /**
      * @var PlainTextSitemapIndexRender

--- a/tests/Render/PlainTextSitemapRenderTest.php
+++ b/tests/Render/PlainTextSitemapRenderTest.php
@@ -11,8 +11,9 @@ namespace GpsLab\Component\Sitemap\Tests\Render;
 
 use GpsLab\Component\Sitemap\Render\PlainTextSitemapRender;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class PlainTextSitemapRenderTest extends \PHPUnit_Framework_TestCase
+class PlainTextSitemapRenderTest extends TestCase
 {
     /**
      * @var PlainTextSitemapRender

--- a/tests/Stream/CompressFileStreamTest.php
+++ b/tests/Stream/CompressFileStreamTest.php
@@ -13,8 +13,9 @@ use GpsLab\Component\Compressor\CompressorInterface;
 use GpsLab\Component\Sitemap\Stream\CompressFileStream;
 use GpsLab\Component\Sitemap\Stream\FileStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class CompressFileStreamTest extends \PHPUnit_Framework_TestCase
+class CompressFileStreamTest extends TestCase
 {
     /**
      * @var CompressFileStream

--- a/tests/Stream/Exception/CompressionLevelExceptionTest.php
+++ b/tests/Stream/Exception/CompressionLevelExceptionTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Stream\Exception;
 
 use GpsLab\Component\Sitemap\Stream\Exception\CompressionLevelException;
+use PHPUnit\Framework\TestCase;
 
-class CompressionLevelExceptionTest extends \PHPUnit_Framework_TestCase
+class CompressionLevelExceptionTest extends TestCase
 {
     public function testInvalid()
     {

--- a/tests/Stream/Exception/FileAccessExceptionTest.php
+++ b/tests/Stream/Exception/FileAccessExceptionTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Stream\Exception;
 
 use GpsLab\Component\Sitemap\Stream\Exception\FileAccessException;
+use PHPUnit\Framework\TestCase;
 
-class FileAccessExceptionTest extends \PHPUnit_Framework_TestCase
+class FileAccessExceptionTest extends TestCase
 {
     public function testNotWritable()
     {

--- a/tests/Stream/Exception/LinksOverflowExceptionTest.php
+++ b/tests/Stream/Exception/LinksOverflowExceptionTest.php
@@ -11,8 +11,9 @@ namespace GpsLab\Component\Sitemap\Tests\Stream\Exception;
 
 use GpsLab\Component\Sitemap\Stream\Exception\LinksOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\OverflowException;
+use PHPUnit\Framework\TestCase;
 
-class LinksOverflowExceptionTest extends \PHPUnit_Framework_TestCase
+class LinksOverflowExceptionTest extends TestCase
 {
     public function testWithLimit()
     {

--- a/tests/Stream/Exception/SizeOverflowExceptionTest.php
+++ b/tests/Stream/Exception/SizeOverflowExceptionTest.php
@@ -11,8 +11,9 @@ namespace GpsLab\Component\Sitemap\Tests\Stream\Exception;
 
 use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\OverflowException;
+use PHPUnit\Framework\TestCase;
 
-class SizeOverflowExceptionTest extends \PHPUnit_Framework_TestCase
+class SizeOverflowExceptionTest extends TestCase
 {
     public function testWithLimit()
     {

--- a/tests/Stream/Exception/StreamStateExceptionTest.php
+++ b/tests/Stream/Exception/StreamStateExceptionTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Stream\Exception;
 
 use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
+use PHPUnit\Framework\TestCase;
 
-class StreamStateExceptionTest extends \PHPUnit_Framework_TestCase
+class StreamStateExceptionTest extends TestCase
 {
     public function testAlreadyOpened()
     {

--- a/tests/Stream/LoggerStreamTest.php
+++ b/tests/Stream/LoggerStreamTest.php
@@ -13,8 +13,9 @@ use GpsLab\Component\Sitemap\Stream\LoggerStream;
 use GpsLab\Component\Sitemap\Url\SmartUrl;
 use GpsLab\Component\Sitemap\Url\Url;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class LoggerStreamTest extends \PHPUnit_Framework_TestCase
+class LoggerStreamTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|LoggerInterface
@@ -71,8 +72,8 @@ class LoggerStreamTest extends \PHPUnit_Framework_TestCase
     {
         $this->stream->open();
         $this->stream->push(new Url('/'));
-        $this->assertEquals(1, count($this->stream));
+        $this->assertCount(1, $this->stream);
         $this->stream->close();
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 }

--- a/tests/Stream/MultiStreamTest.php
+++ b/tests/Stream/MultiStreamTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Sitemap\Tests\Stream;
 use GpsLab\Component\Sitemap\Stream\MultiStream;
 use GpsLab\Component\Sitemap\Stream\Stream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class MultiStreamTest extends \PHPUnit_Framework_TestCase
+class MultiStreamTest extends TestCase
 {
     /**
      * @return array
@@ -126,9 +127,9 @@ class MultiStreamTest extends \PHPUnit_Framework_TestCase
         }
         $stream->push($url);
 
-        $this->assertEquals(1, count($stream));
+        $this->assertCount(1, $stream);
         $stream->close();
-        $this->assertEquals(0, count($stream));
+        $this->assertCount(0, $stream);
     }
 
     /**

--- a/tests/Stream/OutputStreamTest.php
+++ b/tests/Stream/OutputStreamTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\OutputStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class OutputStreamTest extends \PHPUnit_Framework_TestCase
+class OutputStreamTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SitemapRender
@@ -205,9 +206,9 @@ class OutputStreamTest extends \PHPUnit_Framework_TestCase
     {
         $this->open();
         $this->stream->push(new Url('/'));
-        $this->assertEquals(1, count($this->stream));
+        $this->assertCount(1, $this->stream);
         $this->close();
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     private function open()

--- a/tests/Stream/RenderBzip2FileStreamTest.php
+++ b/tests/Stream/RenderBzip2FileStreamTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\RenderBzip2FileStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class RenderBzip2FileStreamTest extends \PHPUnit_Framework_TestCase
+class RenderBzip2FileStreamTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SitemapRender
@@ -224,9 +225,9 @@ class RenderBzip2FileStreamTest extends \PHPUnit_Framework_TestCase
     {
         $this->open();
         $this->stream->push(new Url('/'));
-        $this->assertEquals(1, count($this->stream));
+        $this->assertCount(1, $this->stream);
         $this->close();
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     private function open()

--- a/tests/Stream/RenderFileStreamTest.php
+++ b/tests/Stream/RenderFileStreamTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\RenderFileStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class RenderFileStreamTest extends \PHPUnit_Framework_TestCase
+class RenderFileStreamTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SitemapRender
@@ -224,9 +225,9 @@ class RenderFileStreamTest extends \PHPUnit_Framework_TestCase
     {
         $this->open();
         $this->stream->push(new Url('/'));
-        $this->assertEquals(1, count($this->stream));
+        $this->assertCount(1, $this->stream);
         $this->close();
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     private function open()

--- a/tests/Stream/RenderGzipFileStreamTest.php
+++ b/tests/Stream/RenderGzipFileStreamTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\RenderGzipFileStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class RenderGzipFileStreamTest extends \PHPUnit_Framework_TestCase
+class RenderGzipFileStreamTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SitemapRender
@@ -248,9 +249,9 @@ class RenderGzipFileStreamTest extends \PHPUnit_Framework_TestCase
     {
         $this->open();
         $this->stream->push(new Url('/'));
-        $this->assertEquals(1, count($this->stream));
+        $this->assertCount(1, $this->stream);
         $this->close();
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     private function open()

--- a/tests/Stream/RenderIndexFileStreamTest.php
+++ b/tests/Stream/RenderIndexFileStreamTest.php
@@ -17,8 +17,9 @@ use GpsLab\Component\Sitemap\Stream\FileStream;
 use GpsLab\Component\Sitemap\Stream\RenderFileStream;
 use GpsLab\Component\Sitemap\Stream\RenderIndexFileStream;
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class RenderIndexFileStreamTest extends \PHPUnit_Framework_TestCase
+class RenderIndexFileStreamTest extends TestCase
 {
     /**
      * @var SitemapIndexRender
@@ -208,7 +209,7 @@ class RenderIndexFileStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($this->filename);
         $this->assertFileExists(sys_get_temp_dir().'/'.$indexed_filename);
         $this->assertEquals(count($urls), $total);
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     public function testOverflow()
@@ -226,7 +227,7 @@ class RenderIndexFileStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists(sys_get_temp_dir().'/sitemap2.xml');
         $this->assertFileNotExists(sys_get_temp_dir().'/sitemap3.xml');
         $this->assertEquals(RenderFileStream::LINKS_LIMIT + 1, $total);
-        $this->assertEquals(0, count($this->stream));
+        $this->assertCount(0, $this->stream);
     }
 
     /**

--- a/tests/Stream/State/StreamStateTest.php
+++ b/tests/Stream/State/StreamStateTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Stream\State;
 
 use GpsLab\Component\Sitemap\Stream\State\StreamState;
+use PHPUnit\Framework\TestCase;
 
-class StreamStateTest extends \PHPUnit_Framework_TestCase
+class StreamStateTest extends TestCase
 {
     /**
      * @var StreamState

--- a/tests/Url/SmartUrlTest.php
+++ b/tests/Url/SmartUrlTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Url;
 
 use GpsLab\Component\Sitemap\Url\SmartUrl;
+use PHPUnit\Framework\TestCase;
 
-class SmartUrlTest extends \PHPUnit_Framework_TestCase
+class SmartUrlTest extends TestCase
 {
     public function testDefaultUrl()
     {

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Sitemap\Tests\Url;
 
 use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
     public function testDefaultUrl()
     {


### PR DESCRIPTION
# Changed log
- To be compatible with future PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace instead.
- The `satooshi/php-coveralls` is deprecated, using the `php-coveralls/php-coveralls` instead.
- 