### PR TITLE
Mark Renders and Streams as final classes

### DIFF
--- a/src/Builder/Url/MultiUrlBuilder.php
+++ b/src/Builder/Url/MultiUrlBuilder.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Builder\Url;
 
 use GpsLab\Component\Sitemap\Url\Url;
 
-class MultiUrlBuilder implements UrlBuilder
+final class MultiUrlBuilder implements UrlBuilder
 {
     /**
      * @var iterable[]

--- a/src/Render/PlainTextSitemapIndexRender.php
+++ b/src/Render/PlainTextSitemapIndexRender.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Render;
 
 use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 
-class PlainTextSitemapIndexRender implements SitemapIndexRender
+final class PlainTextSitemapIndexRender implements SitemapIndexRender
 {
     /**
      * @var string

--- a/src/Render/PlainTextSitemapRender.php
+++ b/src/Render/PlainTextSitemapRender.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Render;
 
 use GpsLab\Component\Sitemap\Url\Url;
 
-class PlainTextSitemapRender implements SitemapRender
+final class PlainTextSitemapRender implements SitemapRender
 {
     /**
      * @var string

--- a/src/Render/XMLWriterSitemapIndexRender.php
+++ b/src/Render/XMLWriterSitemapIndexRender.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Render;
 
 use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 
-class XMLWriterSitemapIndexRender implements SitemapIndexRender
+final class XMLWriterSitemapIndexRender implements SitemapIndexRender
 {
     /**
      * @var \XMLWriter

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Render;
 
 use GpsLab\Component\Sitemap\Url\Url;
 
-class XMLWriterSitemapRender implements SitemapRender
+final class XMLWriterSitemapRender implements SitemapRender
 {
     /**
      * @var \XMLWriter

--- a/src/Sitemap/Exception/InvalidArgumentException.php
+++ b/src/Sitemap/Exception/InvalidArgumentException.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Sitemap\Sitemap\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException
+abstract class InvalidArgumentException extends \InvalidArgumentException
 {
 }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -17,7 +17,7 @@ use GpsLab\Component\Sitemap\Sitemap\Exception\InvalidLocationException;
 /**
  * The part of sitemap index.
  */
-final class Sitemap
+class Sitemap
 {
     /**
      * @var string

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -17,7 +17,7 @@ use GpsLab\Component\Sitemap\Sitemap\Exception\InvalidLocationException;
 /**
  * The part of sitemap index.
  */
-class Sitemap
+final class Sitemap
 {
     /**
      * @var string

--- a/src/Stream/LoggerStream.php
+++ b/src/Stream/LoggerStream.php
@@ -13,7 +13,7 @@ namespace GpsLab\Component\Sitemap\Stream;
 use GpsLab\Component\Sitemap\Url\Url;
 use Psr\Log\LoggerInterface;
 
-class LoggerStream implements Stream
+final class LoggerStream implements Stream
 {
     /**
      * @var LoggerInterface

--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -12,7 +12,7 @@ namespace GpsLab\Component\Sitemap\Stream;
 
 use GpsLab\Component\Sitemap\Url\Url;
 
-class MultiStream implements Stream
+final class MultiStream implements Stream
 {
     /**
      * @var Stream[]

--- a/src/Stream/OutputStream.php
+++ b/src/Stream/OutputStream.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use GpsLab\Component\Sitemap\Url\Url;
 
-class OutputStream implements Stream
+final class OutputStream implements Stream
 {
     /**
      * @var SitemapRender

--- a/src/Stream/WritingIndexStream.php
+++ b/src/Stream/WritingIndexStream.php
@@ -17,7 +17,7 @@ use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use GpsLab\Component\Sitemap\Writer\Writer;
 
-class WritingIndexStream implements IndexStream
+final class WritingIndexStream implements IndexStream
 {
     /**
      * @var SitemapIndexRender

--- a/src/Stream/WritingSplitIndexStream.php
+++ b/src/Stream/WritingSplitIndexStream.php
@@ -21,7 +21,7 @@ use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use GpsLab\Component\Sitemap\Url\Url;
 use GpsLab\Component\Sitemap\Writer\Writer;
 
-class WritingSplitIndexStream implements Stream, IndexStream
+final class WritingSplitIndexStream implements Stream, IndexStream
 {
     /**
      * @var SitemapIndexRender

--- a/src/Stream/WritingSplitStream.php
+++ b/src/Stream/WritingSplitStream.php
@@ -20,7 +20,7 @@ use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use GpsLab\Component\Sitemap\Url\Url;
 use GpsLab\Component\Sitemap\Writer\Writer;
 
-class WritingSplitStream implements SplitStream
+final class WritingSplitStream implements SplitStream
 {
     /**
      * @var SitemapRender

--- a/src/Stream/WritingStream.php
+++ b/src/Stream/WritingStream.php
@@ -17,7 +17,7 @@ use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use GpsLab\Component\Sitemap\Url\Url;
 use GpsLab\Component\Sitemap\Writer\Writer;
 
-class WritingStream implements Stream
+final class WritingStream implements Stream
 {
     /**
      * @var SitemapRender

--- a/src/Url/Exception/InvalidArgumentException.php
+++ b/src/Url/Exception/InvalidArgumentException.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Sitemap\Url\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException
+abstract class InvalidArgumentException extends \InvalidArgumentException
 {
 }

--- a/src/Writer/DeflateFileWriter.php
+++ b/src/Writer/DeflateFileWriter.php
@@ -19,7 +19,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class DeflateFileWriter implements Writer
+final class DeflateFileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/src/Writer/DeflateTempFileWriter.php
+++ b/src/Writer/DeflateTempFileWriter.php
@@ -19,7 +19,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class DeflateTempFileWriter implements Writer
+final class DeflateTempFileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class FileWriter implements Writer
+final class FileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/src/Writer/GzipFileWriter.php
+++ b/src/Writer/GzipFileWriter.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class GzipFileWriter implements Writer
+final class GzipFileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/src/Writer/GzipTempFileWriter.php
+++ b/src/Writer/GzipTempFileWriter.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class GzipTempFileWriter implements Writer
+final class GzipTempFileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/src/Writer/TempFileWriter.php
+++ b/src/Writer/TempFileWriter.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 
-class TempFileWriter implements Writer
+final class TempFileWriter implements Writer
 {
     /**
      * @var resource|null

--- a/tests/Builder/Url/MultiUrlBuilderTest.php
+++ b/tests/Builder/Url/MultiUrlBuilderTest.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class MultiUrlBuilderTest extends TestCase
+final class MultiUrlBuilderTest extends TestCase
 {
     public function testIterate(): void
     {

--- a/tests/LimiterTest.php
+++ b/tests/LimiterTest.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Stream\Exception\SitemapsOverflowException;
 use GpsLab\Component\Sitemap\Stream\Exception\SizeOverflowException;
 use PHPUnit\Framework\TestCase;
 
-class LimiterTest extends TestCase
+final class LimiterTest extends TestCase
 {
     /**
      * @var Limiter

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -13,7 +13,7 @@ namespace GpsLab\Component\Sitemap\Tests;
 use GpsLab\Component\Sitemap\Location;
 use PHPUnit\Framework\TestCase;
 
-class LocationTest extends TestCase
+final class LocationTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Render/PlainTextSitemapIndexRenderTest.php
+++ b/tests/Render/PlainTextSitemapIndexRenderTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Render\PlainTextSitemapIndexRender;
 use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 use PHPUnit\Framework\TestCase;
 
-class PlainTextSitemapIndexRenderTest extends TestCase
+final class PlainTextSitemapIndexRenderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Render/PlainTextSitemapRenderTest.php
+++ b/tests/Render/PlainTextSitemapRenderTest.php
@@ -15,7 +15,7 @@ use GpsLab\Component\Sitemap\Url\ChangeFrequency;
 use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\TestCase;
 
-class PlainTextSitemapRenderTest extends TestCase
+final class PlainTextSitemapRenderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Render/XMLWriterSitemapIndexRenderTest.php
+++ b/tests/Render/XMLWriterSitemapIndexRenderTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Render\XMLWriterSitemapIndexRender;
 use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 use PHPUnit\Framework\TestCase;
 
-class XMLWriterSitemapIndexRenderTest extends TestCase
+final class XMLWriterSitemapIndexRenderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Render/XMLWriterSitemapRenderTest.php
+++ b/tests/Render/XMLWriterSitemapRenderTest.php
@@ -15,7 +15,7 @@ use GpsLab\Component\Sitemap\Url\ChangeFrequency;
 use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\TestCase;
 
-class XMLWriterSitemapRenderTest extends TestCase
+final class XMLWriterSitemapRenderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Sitemap/SitemapTest.php
+++ b/tests/Sitemap/SitemapTest.php
@@ -15,7 +15,7 @@ use GpsLab\Component\Sitemap\Sitemap\Exception\InvalidLocationException;
 use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 use PHPUnit\Framework\TestCase;
 
-class SitemapTest extends TestCase
+final class SitemapTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Stream/LoggerStreamTest.php
+++ b/tests/Stream/LoggerStreamTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class LoggerStreamTest extends TestCase
+final class LoggerStreamTest extends TestCase
 {
     /**
      * @var MockObject|LoggerInterface

--- a/tests/Stream/MultiStreamTest.php
+++ b/tests/Stream/MultiStreamTest.php
@@ -16,7 +16,7 @@ use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class MultiStreamTest extends TestCase
+final class MultiStreamTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Stream/OutputStreamTest.php
+++ b/tests/Stream/OutputStreamTest.php
@@ -20,7 +20,7 @@ use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class OutputStreamTest extends TestCase
+final class OutputStreamTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Stream/State/StreamStateTest.php
+++ b/tests/Stream/State/StreamStateTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
 use GpsLab\Component\Sitemap\Stream\State\StreamState;
 use PHPUnit\Framework\TestCase;
 
-class StreamStateTest extends TestCase
+final class StreamStateTest extends TestCase
 {
     /**
      * @var StreamState

--- a/tests/Stream/WritingIndexStreamTest.php
+++ b/tests/Stream/WritingIndexStreamTest.php
@@ -20,7 +20,7 @@ use GpsLab\Component\Sitemap\Writer\Writer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class WritingIndexStreamTest extends TestCase
+final class WritingIndexStreamTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Stream/WritingSplitIndexStreamTest.php
+++ b/tests/Stream/WritingSplitIndexStreamTest.php
@@ -27,7 +27,7 @@ use GpsLab\Component\Sitemap\Writer\Writer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class WritingSplitIndexStreamTest extends TestCase
+final class WritingSplitIndexStreamTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Stream/WritingSplitStreamTest.php
+++ b/tests/Stream/WritingSplitStreamTest.php
@@ -21,7 +21,7 @@ use GpsLab\Component\Sitemap\Writer\Writer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class WritingSplitStreamTest extends TestCase
+final class WritingSplitStreamTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Stream/WritingStreamTest.php
+++ b/tests/Stream/WritingStreamTest.php
@@ -21,7 +21,7 @@ use GpsLab\Component\Sitemap\Writer\Writer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class WritingStreamTest extends TestCase
+final class WritingStreamTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Url/ChangeFrequencyTest.php
+++ b/tests/Url/ChangeFrequencyTest.php
@@ -13,7 +13,7 @@ namespace GpsLab\Component\Sitemap\Tests\Url;
 use GpsLab\Component\Sitemap\Url\ChangeFrequency;
 use PHPUnit\Framework\TestCase;
 
-class ChangeFrequencyTest extends TestCase
+final class ChangeFrequencyTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Url/PriorityTest.php
+++ b/tests/Url/PriorityTest.php
@@ -13,7 +13,7 @@ namespace GpsLab\Component\Sitemap\Tests\Url;
 use GpsLab\Component\Sitemap\Url\Priority;
 use PHPUnit\Framework\TestCase;
 
-class PriorityTest extends TestCase
+final class PriorityTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Url/SmartUrlTest.php
+++ b/tests/Url/SmartUrlTest.php
@@ -19,7 +19,7 @@ use GpsLab\Component\Sitemap\Url\Priority;
 use GpsLab\Component\Sitemap\Url\SmartUrl;
 use PHPUnit\Framework\TestCase;
 
-class SmartUrlTest extends TestCase
+final class SmartUrlTest extends TestCase
 {
     public function testDefaultUrl(): void
     {

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -18,7 +18,7 @@ use GpsLab\Component\Sitemap\Url\Exception\InvalidPriorityException;
 use GpsLab\Component\Sitemap\Url\Url;
 use PHPUnit\Framework\TestCase;
 
-class UrlTest extends TestCase
+final class UrlTest extends TestCase
 {
     public function testDefaultUrl(): void
     {

--- a/tests/Writer/DeflateFileWriterTest.php
+++ b/tests/Writer/DeflateFileWriterTest.php
@@ -18,7 +18,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\CompressionWindowException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use PHPUnit\Framework\TestCase;
 
-class DeflateFileWriterTest extends TestCase
+final class DeflateFileWriterTest extends TestCase
 {
     private const ENCODINGS = [ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP, ZLIB_ENCODING_DEFLATE];
 

--- a/tests/Writer/DeflateTempFileWriterTest.php
+++ b/tests/Writer/DeflateTempFileWriterTest.php
@@ -18,7 +18,7 @@ use GpsLab\Component\Sitemap\Writer\Exception\CompressionWindowException;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use PHPUnit\Framework\TestCase;
 
-class DeflateTempFileWriterTest extends TestCase
+final class DeflateTempFileWriterTest extends TestCase
 {
     private const ENCODINGS = [ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP, ZLIB_ENCODING_DEFLATE];
 

--- a/tests/Writer/Exception/CompressionLevelExceptionTest.php
+++ b/tests/Writer/Exception/CompressionLevelExceptionTest.php
@@ -13,13 +13,12 @@ namespace GpsLab\Component\Sitemap\Tests\Writer\Exception;
 use GpsLab\Component\Sitemap\Writer\Exception\CompressionLevelException;
 use PHPUnit\Framework\TestCase;
 
-class CompressionLevelExceptionTest extends TestCase
+final class CompressionLevelExceptionTest extends TestCase
 {
     public function testInvalid(): void
     {
         $exception = CompressionLevelException::invalid('foo', 0, 10);
 
-        self::assertInstanceOf(CompressionLevelException::class, $exception);
         self::assertInstanceOf(\InvalidArgumentException::class, $exception);
         self::assertEquals('The compression level "foo" must be in interval [0, 10].', $exception->getMessage());
     }

--- a/tests/Writer/Exception/DeflateCompressionExceptionTest.php
+++ b/tests/Writer/Exception/DeflateCompressionExceptionTest.php
@@ -13,7 +13,7 @@ namespace GpsLab\Component\Sitemap\Tests\Writer\Exception;
 use GpsLab\Component\Sitemap\Writer\Exception\DeflateCompressionException;
 use PHPUnit\Framework\TestCase;
 
-class DeflateCompressionExceptionTest extends TestCase
+final class DeflateCompressionExceptionTest extends TestCase
 {
     public function testFailedAdd(): void
     {

--- a/tests/Writer/Exception/ExtensionNotLoadedExceptionTest.php
+++ b/tests/Writer/Exception/ExtensionNotLoadedExceptionTest.php
@@ -13,13 +13,12 @@ namespace GpsLab\Component\Sitemap\Tests\Writer\Exception;
 use GpsLab\Component\Sitemap\Writer\Exception\ExtensionNotLoadedException;
 use PHPUnit\Framework\TestCase;
 
-class ExtensionNotLoadedExceptionTest extends TestCase
+final class ExtensionNotLoadedExceptionTest extends TestCase
 {
     public function testZlib(): void
     {
         $exception = ExtensionNotLoadedException::zlib();
 
-        self::assertInstanceOf(ExtensionNotLoadedException::class, $exception);
         self::assertInstanceOf(\RuntimeException::class, $exception);
         self::assertEquals('The Zlib PHP extension is not loaded.', $exception->getMessage());
     }

--- a/tests/Writer/Exception/FileAccessExceptionTest.php
+++ b/tests/Writer/Exception/FileAccessExceptionTest.php
@@ -13,13 +13,12 @@ namespace GpsLab\Component\Sitemap\Tests\Writer\Exception;
 use GpsLab\Component\Sitemap\Writer\Exception\FileAccessException;
 use PHPUnit\Framework\TestCase;
 
-class FileAccessExceptionTest extends TestCase
+final class FileAccessExceptionTest extends TestCase
 {
     public function testNotWritable(): void
     {
         $exception = FileAccessException::notWritable('foo');
 
-        self::assertInstanceOf(FileAccessException::class, $exception);
         self::assertInstanceOf(\RuntimeException::class, $exception);
         self::assertEquals('File "foo" is not writable.', $exception->getMessage());
     }
@@ -28,7 +27,6 @@ class FileAccessExceptionTest extends TestCase
     {
         $exception = FileAccessException::failedOverwrite('foo', 'bar');
 
-        self::assertInstanceOf(FileAccessException::class, $exception);
         self::assertInstanceOf(\RuntimeException::class, $exception);
         self::assertEquals('Failed to overwrite file "bar" from temporary file "foo".', $exception->getMessage());
     }

--- a/tests/Writer/FileWriterTest.php
+++ b/tests/Writer/FileWriterTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Writer\FileWriter;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use PHPUnit\Framework\TestCase;
 
-class FileWriterTest extends TestCase
+final class FileWriterTest extends TestCase
 {
     /**
      * @var FileWriter

--- a/tests/Writer/GzipFileWriterTest.php
+++ b/tests/Writer/GzipFileWriterTest.php
@@ -15,7 +15,7 @@ use GpsLab\Component\Sitemap\Writer\GzipFileWriter;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use PHPUnit\Framework\TestCase;
 
-class GzipFileWriterTest extends TestCase
+final class GzipFileWriterTest extends TestCase
 {
     /**
      * @var GzipFileWriter

--- a/tests/Writer/GzipTempFileWriterTest.php
+++ b/tests/Writer/GzipTempFileWriterTest.php
@@ -15,7 +15,7 @@ use GpsLab\Component\Sitemap\Writer\GzipTempFileWriter;
 use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use PHPUnit\Framework\TestCase;
 
-class GzipTempFileWriterTest extends TestCase
+final class GzipTempFileWriterTest extends TestCase
 {
     /**
      * @var GzipTempFileWriter

--- a/tests/Writer/State/WriterStateTest.php
+++ b/tests/Writer/State/WriterStateTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\State\WriterState;
 use PHPUnit\Framework\TestCase;
 
-class WriterStateTest extends TestCase
+final class WriterStateTest extends TestCase
 {
     /**
      * @var WriterState

--- a/tests/Writer/TempFileWriterTest.php
+++ b/tests/Writer/TempFileWriterTest.php
@@ -14,7 +14,7 @@ use GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException;
 use GpsLab\Component\Sitemap\Writer\TempFileWriter;
 use PHPUnit\Framework\TestCase;
 
-class TempFileWriterTest extends TestCase
+final class TempFileWriterTest extends TestCase
 {
     /**
      * @var TempFileWriter


### PR DESCRIPTION
*Composition over inheritance*

Renders and Streams are not intended to extending.
If you need to change the behavior of the Renders or Streams, then it is better to create your own Render or Stream completely and use the existing one inside if necessary.