### PR TITLE
Fix error in unit test on Windows

### DIFF
--- a/tests/Stream/WritingSplitIndexStreamTest.php
+++ b/tests/Stream/WritingSplitIndexStreamTest.php
@@ -338,7 +338,8 @@ final class WritingSplitIndexStreamTest extends TestCase
 
         $writer = new FileWriter();
         $this->tmp_index_filename = $this->tempnam(sys_get_temp_dir(), 'sitemap');
-        $this->tmp_part_filename = $this->tempnam(sys_get_temp_dir(), 'sitemap%d');
+        // Windows uses only the first 3 characters of the prefix
+        $this->tmp_part_filename = $this->tempnam(sys_get_temp_dir(), 's%d');
 
         $stream = new WritingSplitIndexStream(
             new PlainTextSitemapIndexRender('https://example.com'),


### PR DESCRIPTION
Fix error in `GpsLab\Component\Sitemap\Tests\Stream\WritingSplitIndexStreamTest::testConflictWriters`:

```
Failed asserting that exception of type "GpsLab\Component\Sitemap\Stream\Exception\SplitIndexException" matches expected exception "GpsLab\Component\Sitemap\Writer\State\Exception\WriterStateException". Message was: "The pattern "C:\Windows\Temp\sit76CC.tmp" of index part filename is invalid. The pattern should contain a directive like this "/var/www/sitemap%d.xml""
```

Windows uses only the first 3 characters of the prefix in `tempnam()` function.
https://www.php.net/manual/en/function.tempnam.php