### PR TITLE
Language locations should be unique in Url::createLanguageUrls()

### DIFF
--- a/src/Url/Url.php
+++ b/src/Url/Url.php
@@ -142,7 +142,7 @@ class Url
         $external_languages = array_replace($external_languages, $languages);
         $urls = [];
 
-        foreach ($languages as $location) {
+        foreach (array_unique(array_values($languages)) as $location) {
             $urls[] = new self(
                 $location,
                 $last_modify,


### PR DESCRIPTION
In `Url::createLanguageUrls()` you can use one location for several languages, but it should create `Url` classes with unique locations.