### PR TITLE
Scope tracking

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,5 @@
 preset: symfony
 
-enabled:
-  - short_array_syntax
-
 disabled:
   - single_line_throw
   - blank_line_after_opening_tag

--- a/README.md
+++ b/README.md
@@ -61,28 +61,25 @@ composer require gpslab/sitemap
 // URLs on your site
 $urls = [
     Url::create(
-        '/', // loc
+        'https://example.com/', // loc
         new \DateTimeImmutable('2020-06-15 13:39:46'), // lastmod
         ChangeFrequency::always(), // changefreq
         10 // priority
     ),
     Url::create(
-        '/contacts.html',
+        'https://example.com/contacts.html',
         new \DateTimeImmutable('2020-05-26 09:28:12'),
         ChangeFrequency::monthly(),
         7
     ),
-    Url::create('/about.html'),
+    Url::create('https://example.com/about.html'),
 ];
 
 // file into which we will write a sitemap
 $filename = __DIR__.'/sitemap.xml';
 
-// web path to pages on your site
-$web_path = 'https://example.com';
-
 // configure stream
-$render = new PlainTextSitemapRender($web_path);
+$render = new PlainTextSitemapRender();
 $writer = new TempFileWriter();
 $stream = new WritingStream($render, $writer, $filename);
 
@@ -183,42 +180,42 @@ region.
 // URLs on your site
 $urls = [
     Url::create(
-        '/english/page.html',
+        'https://example.com/english/page.html',
         new \DateTimeImmutable('2020-06-15 13:39:46'),
         ChangeFrequency::monthly(),
         7,
         [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
             'fr' => 'https://example.fr',
-            'x-default' => '/english/page.html',
+            'x-default' => 'https://example.com/english/page.html',
         ]
     ),
     Url::create(
-        '/deutsch/page.html',
+        'https://example.com/deutsch/page.html',
         new \DateTimeImmutable('2020-06-15 13:39:46'),
         ChangeFrequency::monthly(),
         7,
         [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
             'fr' => 'https://example.fr',
-            'x-default' => '/english/page.html',
+            'x-default' => 'https://example.com/english/page.html',
         ]
     ),
     Url::create(
-        '/schweiz-deutsch/page.html',
+        'https://example.com/schweiz-deutsch/page.html',
         new \DateTimeImmutable('2020-06-15 13:39:46'),
         ChangeFrequency::monthly(),
         7,
         [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
             'fr' => 'https://example.fr',
-            'x-default' => '/english/page.html',
+            'x-default' => 'https://example.com/english/page.html',
         ]
     ),
 ];
@@ -229,10 +226,10 @@ You can simplify the creation of URLs for localized versions of the same page wi
 ```php
 $urls = Url::createLanguageUrls(
     [
-        'de' => '/deutsch/page.html',
-        'de-ch' => '/schweiz-deutsch/page.html',
-        'en' => '/english/page.html',
-        'x-default' => '/english/page.html',
+        'de' => 'https://example.com/deutsch/page.html',
+        'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+        'en' => 'https://example.com/english/page.html',
+        'x-default' => 'https://example.com/english/page.html',
     ],
     new \DateTimeImmutable('2020-06-15 13:39:46'),
     ChangeFrequency::monthly(),
@@ -293,19 +290,19 @@ class MySiteUrlBuilder implements UrlBuilder
         // add URLs on your site
         return new \ArrayIterator([
           Url::create(
-              '/', // loc
+              'https://example.com/', // loc
               new \DateTimeImmutable('2020-06-15 13:39:46'), // lastmod
               ChangeFrequency::always(), // changefreq
               10 // priority
           ),
           Url::create(
-              '/contacts.html',
+              'https://example.com/contacts.html',
               new \DateTimeImmutable('2020-05-26 09:28:12'),
               ChangeFrequency::monthly(),
               7
           ),
           Url::create(
-              '/about.html',
+              'https://example.com/about.html',
               new \DateTimeImmutable('2020-05-02 17:12:38'),
               ChangeFrequency::monthly(),
               7
@@ -339,14 +336,14 @@ class ArticlesUrlBuilder implements UrlBuilder
 
             // smart URL automatically fills fields that it can
             yield Url::createSmart(
-                sprintf('/article/%d', $row['id']),
+                sprintf('https://example.com/article/%d', $row['id']),
                 $update_at
             );
         }
 
         // link to section
         yield Url::create(
-            '/article/',
+            'https://example.com/article/',
             $section_update_at ?: new \DateTimeImmutable('-1 day'),
             ChangeFrequency::daily(),
             9
@@ -367,11 +364,8 @@ $builders = new MultiUrlBuilder([
 // file into which we will write a sitemap
 $filename = __DIR__.'/sitemap.xml';
 
-// web path to pages on your site
-$web_path = 'https://example.com';
-
 // configure stream
-$render = new PlainTextSitemapRender($web_path);
+$render = new PlainTextSitemapRender();
 $writer = new TempFileWriter();
 $stream = new WritingStream($render, $writer, $filename);
 
@@ -392,19 +386,16 @@ have already created portions of the Sitemap, you can simply create the Sitemap 
 // file into which we will write a sitemap
 $filename = __DIR__.'/sitemap.xml';
 
-// web path to the sitemap.xml on your site
-$web_path = 'https://example.com';
-
 // configure stream
-$render = new PlainTextSitemapIndexRender($web_path);
+$render = new PlainTextSitemapIndexRender();
 $writer = new TempFileWriter();
 $stream = new WritingIndexStream($render, $writer, $filename);
 
 // build sitemap.xml index
 $stream->open();
-$stream->pushSitemap(new Sitemap('/sitemap_main.xml', new \DateTimeImmutable('-1 hour')));
-$stream->pushSitemap(new Sitemap('/sitemap_news.xml', new \DateTimeImmutable('-1 hour')));
-$stream->pushSitemap(new Sitemap('/sitemap_articles.xml', new \DateTimeImmutable('-1 hour')));
+$stream->pushSitemap(new Sitemap('https://example.com/sitemap_main.xml', new \DateTimeImmutable('-1 hour')));
+$stream->pushSitemap(new Sitemap('https://example.com/sitemap_news.xml', new \DateTimeImmutable('-1 hour')));
+$stream->pushSitemap(new Sitemap('https://example.com/sitemap_articles.xml', new \DateTimeImmutable('-1 hour')));
 $stream->close();
 ```
 
@@ -429,20 +420,17 @@ $builders = new MultiUrlBuilder([
 // file into which we will write a sitemap
 $index_filename = __DIR__.'/sitemap.xml';
 
-// web path to the sitemap.xml on your site
-$index_web_path = 'https://example.com';
-
-$index_render = new PlainTextSitemapIndexRender($index_web_path);
+$index_render = new PlainTextSitemapIndexRender();
 $index_writer = new TempFileWriter();
 
 // file into which we will write a sitemap part
 // filename should contain a directive like "%d"
 $part_filename = __DIR__.'/sitemap%d.xml';
 
-// web path to pages on your site
-$part_web_path = 'https://example.com';
+// web path to the sitemap.xml on your site
+$part_web_path = 'https://example.com/sitemap%d.xml';
 
-$part_render = new PlainTextSitemapRender($part_web_path);
+$part_render = new PlainTextSitemapRender();
 // separate writer for part
 // it's better not to use one writer as a part writer and a index writer
 // this can cause conflicts in the writer
@@ -455,7 +443,8 @@ $stream = new WritingSplitIndexStream(
     $index_writer,
     $part_writer,
     $index_filename,
-    $part_filename
+    $part_filename,
+    $part_web_path
 );
 
 $stream->open();
@@ -472,7 +461,7 @@ foreach ($builders as $url) {
 }
 
 // you can add a link to a sitemap created earlier
-$stream->pushSitemap(new Sitemap('/sitemap_news.xml', new \DateTimeImmutable('-1 hour')));
+$stream->pushSitemap(new Sitemap('https://example.com/sitemap_news.xml', new \DateTimeImmutable('-1 hour')));
 
 $stream->close();
 ```
@@ -502,18 +491,12 @@ can use a lot of memory.*
 // file into which we will write a sitemap
 $index_filename = __DIR__.'/sitemap.xml';
 
-// web path to the sitemap.xml on your site
-$index_web_path = 'https://example.com';
-
-$index_render = new PlainTextSitemapIndexRender($index_web_path);
+$index_render = new PlainTextSitemapIndexRender();
 $index_writer = new TempFileWriter();
-
-// web path to pages on your site
-$part_web_path = 'https://example.com';
 
 // separate writer for part
 $part_writer = new TempFileWriter();
-$part_render = new PlainTextSitemapRender($part_web_path);
+$part_render = new PlainTextSitemapRender();
 
 // create a stream for news
 
@@ -610,12 +593,13 @@ You can use a composition of streams.
 $stream = new MultiStream(
     new LoggerStream(/* $logger */),
     new WritingSplitIndexStream(
-        new PlainTextSitemapIndexRender('https://example.com'),
-        new PlainTextSitemapRender('https://example.com'),
+        new PlainTextSitemapIndexRender(),
+        new PlainTextSitemapRender(),
         new TempFileWriter(),
         new GzipTempFileWriter(9),
          __DIR__.'/sitemap.xml',
-         __DIR__.'/sitemap%d.xml.gz'
+         __DIR__.'/sitemap%d.xml.gz',
+        'https://example.com/sitemap%d.xml.gz',
     )
 );
 ```
@@ -623,7 +607,7 @@ $stream = new MultiStream(
 Streaming to file and compress result without index.
 
 ```php
-$render = new PlainTextSitemapRender('https://example.com');
+$render = new PlainTextSitemapRender();
 
 $stream = new MultiStream(
     new LoggerStream(/* $logger */),
@@ -635,7 +619,7 @@ $stream = new MultiStream(
 Streaming to file and output buffer.
 
 ```php
-$render = new PlainTextSitemapRender('https://example.com');
+$render = new PlainTextSitemapRender();
 
 $stream = new MultiStream(
     new LoggerStream(/* $logger */),

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,7 +34,7 @@
   ```
 
 * The `$host` argument in `RenderIndexFileStream::__construct()` was removed.
-* The `$web_path` argument in `PlainTextSitemapIndexRender::__construct()` was added.
+* The `$web_path` argument in `PlainTextSitemapIndexRender::__construct()` was removed.
 
   Before:
 
@@ -47,42 +47,8 @@
   After:
 
   ```php
-  $web_path = 'https://example.com'; // No slash in end of path!
-  $index_render = new PlainTextSitemapIndexRender($web_path);
+  $index_render = new PlainTextSitemapIndexRender();
   $index_stream = new RenderFileStream($index_render, $stream, $filename_index);
-  ```
-
-* The `$web_path` argument in `PlainTextSitemapRender::__construct()` was added.
-
-  Before:
-
-  ```php
-  $render = new PlainTextSitemapRender();
-  $render->url(Url::create('https://example.com'));
-  $render->url(Url::create('https://example.com/about'));
-  ```
-
-  After:
-
-  ```php
-  $web_path = 'https://example.com'; // No slash in end of path!
-  $render = new PlainTextSitemapRender($web_path);
-  $render->url(Url::create('/'));
-  $render->url(Url::create('/about'));
-  ```
-
-* The `$priority` in `URL` class was changed from `string` to `int`.
-
-  Before:
-
-  ```php
-  $url = Url::create('/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::MONTHLY, '0.7');
-  ```
-
-  After:
-
-  ```php
-  $url = Url::create('/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::monthly(), 7);
   ```
 
 * The `CallbackStream` was removed.
@@ -135,13 +101,12 @@
 
   ```php
   $index_filename = __DIR__.'/sitemap.xml';
-  $index_web_path = 'https://example.com';
   $part_filename = __DIR__.'/sitemap%d.xml';
-  $part_web_path = 'https://example.com';
+  $part_web_path = 'https://example.com/sitemap%d.xml';
 
-  $index_render = new PlainTextSitemapIndexRender($index_web_path);
+  $index_render = new PlainTextSitemapIndexRender();
   $index_writer = new TempFileWriter();
-  $part_render = new PlainTextSitemapRender($part_web_path);
+  $part_render = new PlainTextSitemapRender();
   $part_writer = new TempFileWriter();
 
   $stream = new WritingSplitIndexStream(
@@ -150,7 +115,8 @@
       $index_writer,
       $part_writer,
       $index_filename,
-      $part_filename
+      $part_filename,
+      $part_web_path
   );
   ```
 
@@ -173,7 +139,7 @@
 
   ```php
   
-  $url = Url::create('/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::MONTHLY, '0.7');
+  $url = Url::create('https://example.com/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::MONTHLY, '0.7');
   ```
 
   Or
@@ -181,7 +147,7 @@
   ```php
   
   $url = new Url(
-      new Location('/contacts.html'),
+      new Location('https://example.com/contacts.html'),
       new \DateTimeImmutable('-1 month'),
       ChangeFrequency::monthly(),
       Priority::create(7)
@@ -199,5 +165,34 @@
   After:
 
   ```php
-  $url = Url::createSmart('/article/123');
+  $url = Url::createSmart('https://example.com/article/123');
+  ```
+
+* Use absolute URL in `Url` class.
+
+  Before:
+
+  ```php
+  $url = Url::create('/contacts.html');
+  ```
+
+  After:
+
+  ```php
+  $url = Url::create('https://example.com/contacts.html');
+  ```
+
+* Allow use `int` and `float` as `$priority` in `URL` class.
+
+  Before:
+
+  ```php
+  $url = Url::create('/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::MONTHLY, '0.7');
+  ```
+
+  After:
+
+  ```php
+  $url = Url::create('https://example.com/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::monthly(), 7);
+  $url = Url::create('https://example.com/contacts.html', new \DateTimeImmutable('-1 month'), ChangeFrequency::monthly(), .7);
   ```

--- a/src/Location.php
+++ b/src/Location.php
@@ -38,9 +38,7 @@ final class Location
             throw LocationTooLongException::tooLong($location, self::MAX_LENGTH);
         }
 
-        if (($location && !in_array($location[0], ['/', '?', '#'], true)) ||
-            filter_var(sprintf('https://example.com%s', $location), FILTER_VALIDATE_URL) === false
-        ) {
+        if (filter_var($location, FILTER_VALIDATE_URL) === false) {
             throw InvalidLocationException::invalid($location);
         }
 

--- a/src/Render/PlainTextSitemapIndexRender.php
+++ b/src/Render/PlainTextSitemapIndexRender.php
@@ -15,22 +15,15 @@ use GpsLab\Component\Sitemap\Sitemap\Sitemap;
 final class PlainTextSitemapIndexRender implements SitemapIndexRender
 {
     /**
-     * @var string
-     */
-    private $web_path;
-
-    /**
      * @var bool
      */
     private $validating;
 
     /**
-     * @param string $web_path
-     * @param bool   $validating
+     * @param bool $validating
      */
-    public function __construct(string $web_path, bool $validating = true)
+    public function __construct(bool $validating = true)
     {
-        $this->web_path = $web_path;
         $this->validating = $validating;
     }
 
@@ -69,7 +62,7 @@ final class PlainTextSitemapIndexRender implements SitemapIndexRender
     public function sitemap(Sitemap $sitemap): string
     {
         $result = '<sitemap>';
-        $result .= '<loc>'.htmlspecialchars($this->web_path.$sitemap->getLocation()).'</loc>';
+        $result .= '<loc>'.htmlspecialchars((string) $sitemap->getLocation()).'</loc>';
 
         if ($sitemap->getLastModify()) {
             $result .= '<lastmod>'.$sitemap->getLastModify()->format('c').'</lastmod>';

--- a/src/Render/PlainTextSitemapRender.php
+++ b/src/Render/PlainTextSitemapRender.php
@@ -17,22 +17,15 @@ use GpsLab\Component\Sitemap\Url\Url;
 final class PlainTextSitemapRender implements SitemapRender
 {
     /**
-     * @var string
-     */
-    private $web_path;
-
-    /**
      * @var bool
      */
     private $validating;
 
     /**
-     * @param string $web_path
-     * @param bool   $validating
+     * @param bool $validating
      */
-    public function __construct(string $web_path, bool $validating = true)
+    public function __construct(bool $validating = true)
     {
-        $this->web_path = $web_path;
         $this->validating = $validating;
     }
 
@@ -71,7 +64,7 @@ final class PlainTextSitemapRender implements SitemapRender
      */
     public function url(Url $url): string
     {
-        $location = htmlspecialchars($this->web_path.$url->getLocation());
+        $location = htmlspecialchars((string) $url->getLocation());
 
         if (strlen($location) >= Location::MAX_LENGTH) {
             throw LocationTooLongException::tooLong($location, Location::MAX_LENGTH);
@@ -93,13 +86,7 @@ final class PlainTextSitemapRender implements SitemapRender
         }
 
         foreach ($url->getLanguages() as $language) {
-            // alternate URLs do not need to be in the same domain
-            if ($language->isLocalLocation()) {
-                $location = htmlspecialchars($this->web_path.$language->getLocation());
-            } else {
-                $location = $language->getLocation();
-            }
-
+            $location = htmlspecialchars((string) $language->getLocation());
             $result .= '<xhtml:link rel="alternate" hreflang="'.$language->getLanguage().'" href="'.$location.'"/>';
         }
 

--- a/src/Render/XMLWriterSitemapIndexRender.php
+++ b/src/Render/XMLWriterSitemapIndexRender.php
@@ -25,11 +25,6 @@ final class XMLWriterSitemapIndexRender implements SitemapIndexRender
     private $writer;
 
     /**
-     * @var string
-     */
-    private $web_path;
-
-    /**
      * @var bool
      */
     private $validating;
@@ -40,13 +35,11 @@ final class XMLWriterSitemapIndexRender implements SitemapIndexRender
     private $use_indent;
 
     /**
-     * @param string $web_path
-     * @param bool   $validating
-     * @param bool   $use_indent
+     * @param bool $validating
+     * @param bool $use_indent
      */
-    public function __construct(string $web_path, bool $validating = true, bool $use_indent = false)
+    public function __construct(bool $validating = true, bool $use_indent = false)
     {
-        $this->web_path = $web_path;
         $this->validating = $validating;
         $this->use_indent = $use_indent;
     }
@@ -118,7 +111,7 @@ final class XMLWriterSitemapIndexRender implements SitemapIndexRender
         }
 
         $this->writer->startElement('sitemap');
-        $this->writer->writeElement('loc', $this->web_path.$sitemap->getLocation());
+        $this->writer->writeElement('loc', (string) $sitemap->getLocation());
 
         if ($sitemap->getLastModify()) {
             $this->writer->writeElement('lastmod', $sitemap->getLastModify()->format('c'));

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -27,11 +27,6 @@ final class XMLWriterSitemapRender implements SitemapRender
     private $writer;
 
     /**
-     * @var string
-     */
-    private $web_path;
-
-    /**
      * @var bool
      */
     private $validating;
@@ -42,13 +37,11 @@ final class XMLWriterSitemapRender implements SitemapRender
     private $use_indent;
 
     /**
-     * @param string $web_path
-     * @param bool   $validating
-     * @param bool   $use_indent
+     * @param bool $validating
+     * @param bool $use_indent
      */
-    public function __construct(string $web_path, bool $validating = true, bool $use_indent = false)
+    public function __construct(bool $validating = true, bool $use_indent = false)
     {
-        $this->web_path = $web_path;
         $this->validating = $validating;
         $this->use_indent = $use_indent;
     }
@@ -120,14 +113,14 @@ final class XMLWriterSitemapRender implements SitemapRender
             $this->start();
         }
 
-        $location = htmlspecialchars($this->web_path.$url->getLocation());
+        $location = htmlspecialchars((string) $url->getLocation());
 
         if (strlen($location) >= Location::MAX_LENGTH) {
             throw LocationTooLongException::tooLong($location, Location::MAX_LENGTH);
         }
 
         $this->writer->startElement('url');
-        $this->writer->writeElement('loc', $this->web_path.$url->getLocation());
+        $this->writer->writeElement('loc', (string) $url->getLocation());
 
         if ($url->getLastModify() instanceof \DateTimeInterface) {
             $this->writer->writeElement('lastmod', $url->getLastModify()->format('c'));
@@ -142,12 +135,7 @@ final class XMLWriterSitemapRender implements SitemapRender
         }
 
         foreach ($url->getLanguages() as $language) {
-            // alternate URLs do not need to be in the same domain
-            if ($language->isLocalLocation()) {
-                $location = htmlspecialchars($this->web_path.$language->getLocation());
-            } else {
-                $location = $language->getLocation();
-            }
+            $location = htmlspecialchars((string) $language->getLocation());
 
             $this->writer->startElement('xhtml:link');
             $this->writer->writeAttribute('rel', 'alternate');

--- a/src/Stream/Exception/InvalidScopeException.php
+++ b/src/Stream/Exception/InvalidScopeException.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream\Exception;
+
+use GpsLab\Component\Sitemap\Exception\InvalidArgumentException;
+
+final class InvalidScopeException extends InvalidArgumentException
+{
+    /**
+     * @param string $scope
+     *
+     * @return self
+     */
+    public static function invalid(string $scope): self
+    {
+        return new self(sprintf('You specify "%s" the invalid scope.', $scope));
+    }
+
+    /**
+     * @param string $scope
+     *
+     * @return self
+     */
+    public static function pathOnly(string $scope): self
+    {
+        return new self(sprintf('The scope must not contain URL query or fragment, got "%s" instead.', $scope));
+    }
+
+    /**
+     * @param string $scope
+     *
+     * @return self
+     */
+    public static function notPath(string $scope): self
+    {
+        return new self(sprintf('The scope must contain a URL path to folder, got "%s" instead.', $scope));
+    }
+}

--- a/src/Stream/Exception/OutOfScopeException.php
+++ b/src/Stream/Exception/OutOfScopeException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream\Exception;
+
+final class OutOfScopeException extends \DomainException
+{
+    /**
+     * @param string $location
+     * @param string $scope
+     *
+     * @return OutOfScopeException
+     */
+    public static function outOf(string $location, string $scope): self
+    {
+        return new self(sprintf('The location "%s" is out of scope "%s".', $location, $scope));
+    }
+}

--- a/src/Stream/Scope/LocationScope.php
+++ b/src/Stream/Scope/LocationScope.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream\Scope;
+
+use GpsLab\Component\Sitemap\Location;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+
+final class LocationScope
+{
+    /**
+     * @var string
+     */
+    private $scope;
+
+    /**
+     * @param string $scope
+     */
+    public function __construct(string $scope)
+    {
+        if (filter_var($scope, FILTER_VALIDATE_URL) === false) {
+            throw InvalidScopeException::invalid($scope);
+        }
+
+        // expected: https://example.com/some/path/
+        if (parse_url($scope, PHP_URL_QUERY) || parse_url($scope, PHP_URL_FRAGMENT)) {
+            throw InvalidScopeException::pathOnly($scope);
+        }
+
+        if (substr($scope, -1, 1) !== '/') {
+            throw InvalidScopeException::notPath($scope);
+        }
+
+        $this->scope = $scope;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScope(): string
+    {
+        return $this->scope;
+    }
+
+    /**
+     * @param Location $location
+     *
+     * @return bool
+     */
+    public function inScope(Location $location): bool
+    {
+        return strpos((string) $location, $this->scope) === 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->scope;
+    }
+}

--- a/src/Stream/ScopeTrackingIndexStream.php
+++ b/src/Stream/ScopeTrackingIndexStream.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream;
+
+use GpsLab\Component\Sitemap\Sitemap\Sitemap;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
+use GpsLab\Component\Sitemap\Stream\Scope\LocationScope;
+
+final class ScopeTrackingIndexStream implements IndexStream
+{
+    /**
+     * @var IndexStream
+     */
+    private $wrapped_stream;
+
+    /**
+     * @var LocationScope
+     */
+    private $scope;
+
+    /**
+     * @param IndexStream $wrapped_stream
+     * @param string      $scope
+     *
+     * @throws InvalidScopeException
+     */
+    public function __construct(IndexStream $wrapped_stream, string $scope)
+    {
+        $this->wrapped_stream = $wrapped_stream;
+        $this->scope = new LocationScope($scope);
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function open(): void
+    {
+        $this->wrapped_stream->open();
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function close(): void
+    {
+        $this->wrapped_stream->close();
+    }
+
+    /**
+     * @param Sitemap $sitemap
+     *
+     * @throws StreamStateException
+     */
+    public function pushSitemap(Sitemap $sitemap): void
+    {
+        if (!$this->scope->inScope($sitemap->getLocation())) {
+            throw OutOfScopeException::outOf((string) $sitemap->getLocation(), (string) $this->scope);
+        }
+
+        $this->wrapped_stream->pushSitemap($sitemap);
+    }
+}

--- a/src/Stream/ScopeTrackingSplitStream.php
+++ b/src/Stream/ScopeTrackingSplitStream.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream;
+
+use GpsLab\Component\Sitemap\Sitemap\Sitemap;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
+use GpsLab\Component\Sitemap\Stream\Scope\LocationScope;
+use GpsLab\Component\Sitemap\Url\Url;
+
+final class ScopeTrackingSplitStream implements SplitStream
+{
+    /**
+     * @var SplitStream
+     */
+    private $wrapped_stream;
+
+    /**
+     * @var LocationScope
+     */
+    private $scope;
+
+    /**
+     * @param SplitStream $wrapped_stream
+     * @param string      $scope
+     *
+     * @throws InvalidScopeException
+     */
+    public function __construct(SplitStream $wrapped_stream, string $scope)
+    {
+        $this->wrapped_stream = $wrapped_stream;
+        $this->scope = new LocationScope($scope);
+    }
+
+    /**
+     * @return Sitemap[]|\Traversable
+     */
+    public function getSitemaps(): \Traversable
+    {
+        foreach ($this->wrapped_stream->getSitemaps() as $sitemap) {
+            if (!$this->scope->inScope($sitemap->getLocation())) {
+                throw OutOfScopeException::outOf((string) $sitemap->getLocation(), (string) $this->scope);
+            }
+
+            yield $sitemap;
+        }
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function open(): void
+    {
+        $this->wrapped_stream->open();
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function close(): void
+    {
+        $this->wrapped_stream->close();
+    }
+
+    /**
+     * @param Url $url
+     *
+     * @throws StreamStateException
+     */
+    public function push(Url $url): void
+    {
+        if (!$this->scope->inScope($url->getLocation())) {
+            throw OutOfScopeException::outOf((string) $url->getLocation(), (string) $this->scope);
+        }
+
+        $this->wrapped_stream->push($url);
+    }
+}

--- a/src/Stream/ScopeTrackingStream.php
+++ b/src/Stream/ScopeTrackingStream.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Stream;
+
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\StreamStateException;
+use GpsLab\Component\Sitemap\Stream\Scope\LocationScope;
+use GpsLab\Component\Sitemap\Url\Url;
+
+final class ScopeTrackingStream implements Stream
+{
+    /**
+     * @var Stream
+     */
+    private $wrapped_stream;
+
+    /**
+     * @var LocationScope
+     */
+    private $scope;
+
+    /**
+     * @param Stream $wrapped_stream
+     * @param string $scope
+     *
+     * @throws InvalidScopeException
+     */
+    public function __construct(Stream $wrapped_stream, string $scope)
+    {
+        $this->wrapped_stream = $wrapped_stream;
+        $this->scope = new LocationScope($scope);
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function open(): void
+    {
+        $this->wrapped_stream->open();
+    }
+
+    /**
+     * @throws StreamStateException
+     */
+    public function close(): void
+    {
+        $this->wrapped_stream->close();
+    }
+
+    /**
+     * @param Url $url
+     *
+     * @throws StreamStateException
+     */
+    public function push(Url $url): void
+    {
+        if (!$this->scope->inScope($url->getLocation())) {
+            throw OutOfScopeException::outOf((string) $url->getLocation(), (string) $this->scope);
+        }
+
+        $this->wrapped_stream->push($url);
+    }
+}

--- a/src/Stream/WritingSplitStream.php
+++ b/src/Stream/WritingSplitStream.php
@@ -75,8 +75,8 @@ final class WritingSplitStream implements SplitStream
     /**
      * @param SitemapRender $render
      * @param Writer        $writer
-     * @param string        $filename_pattern
      * @param string        $web_path_pattern
+     * @param string        $filename_pattern
      *
      * @throws SplitIndexException
      */
@@ -84,7 +84,7 @@ final class WritingSplitStream implements SplitStream
         SitemapRender $render,
         Writer $writer,
         string $filename_pattern,
-        string $web_path_pattern = ''
+        string $web_path_pattern
     ) {
         if (
             sprintf($filename_pattern, $this->index) === $filename_pattern ||
@@ -93,11 +93,10 @@ final class WritingSplitStream implements SplitStream
             throw SplitIndexException::invalidPartFilenamePattern($filename_pattern);
         }
 
-        $web_path_pattern = $web_path_pattern ?: '/'.basename($filename_pattern);
-
         if (
             sprintf($web_path_pattern, $this->index) === $web_path_pattern ||
-            sprintf($web_path_pattern, Limiter::SITEMAPS_LIMIT) === $web_path_pattern
+            sprintf($web_path_pattern, Limiter::SITEMAPS_LIMIT) === $web_path_pattern ||
+            filter_var(sprintf($web_path_pattern, $this->index), FILTER_VALIDATE_URL) === false
         ) {
             throw SplitIndexException::invalidPartWebPathPattern($web_path_pattern);
         }

--- a/src/Url/Language.php
+++ b/src/Url/Language.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Sitemap\Url;
 
-use GpsLab\Component\Sitemap\Exception\InvalidLocationException;
+use GpsLab\Component\Sitemap\Location;
 use GpsLab\Component\Sitemap\Url\Exception\InvalidLanguageException;
 
 final class Language
@@ -31,38 +31,25 @@ final class Language
     private $language;
 
     /**
-     * @var string
+     * @var Location
      */
     private $location;
 
     /**
-     * @var bool
-     */
-    private $local_location;
-
-    /**
-     * @param string $language
-     * @param string $location
+     * @param string          $language
+     * @param Location|string $location
      *
      * @throws InvalidLanguageException
      */
-    public function __construct(string $language, string $location)
+    public function __construct(string $language, $location)
     {
         // language in ISO 639-1 and optionally a region in ISO 3166-1 Alpha 2
         if ($language !== self::UNMATCHED_LANGUAGE && !preg_match('/^[a-z]{2}([-_][a-z]{2})?$/i', $language)) {
             throw InvalidLanguageException::invalid($language);
         }
 
-        // localization pages do not need to be in the same domain
-        $this->local_location = !$location || in_array($location[0], ['/', '?', '#'], true);
-        $validate_url = $this->local_location ? sprintf('https://example.com%s', $location) : $location;
-
-        if (filter_var($validate_url, FILTER_VALIDATE_URL) === false) {
-            throw InvalidLocationException::invalid($location);
-        }
-
         $this->language = $language;
-        $this->location = $location;
+        $this->location = $location instanceof Location ? $location : new Location($location);
     }
 
     /**
@@ -74,18 +61,10 @@ final class Language
     }
 
     /**
-     * @return string
+     * @return Location
      */
-    public function getLocation(): string
+    public function getLocation(): Location
     {
         return $this->location;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isLocalLocation(): bool
-    {
-        return $this->local_location;
     }
 }

--- a/src/Url/Priority.php
+++ b/src/Url/Priority.php
@@ -95,8 +95,10 @@ final class Priority
      */
     public static function createByLocation(Location $location): self
     {
+        $location = parse_url($location->getLocation(), PHP_URL_PATH);
+        $location = trim((string) $location, '/');
         // number of slashes
-        $num = count(array_filter(explode('/', trim((string) $location, '/'))));
+        $num = count(array_filter(explode('/', $location)));
 
         if (!$num) {
             return self::safeCreate('1.0');

--- a/tests/Builder/Url/MultiUrlBuilderTest.php
+++ b/tests/Builder/Url/MultiUrlBuilderTest.php
@@ -22,12 +22,12 @@ final class MultiUrlBuilderTest extends TestCase
     {
         $urls = [];
         $builders = [
-            $this->createUrlBuilder($urls, '/news', 3),
-            $this->createUrlBuilder($urls, '/articles', 3),
+            $this->createUrlBuilder($urls, 'https://example.com/news', 3),
+            $this->createUrlBuilder($urls, 'https://example.com/articles', 3),
         ];
         $builder = new MultiUrlBuilder($builders);
 
-        $builder->add($this->createUrlBuilder($urls, '/posts', 3));
+        $builder->add($this->createUrlBuilder($urls, 'https://example.com/posts', 3));
 
         foreach ($builder as $i => $url) {
             self::assertEquals($urls[$i], $url);

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -23,13 +23,13 @@ final class LocationTest extends TestCase
     public function getValidLocations(): array
     {
         return [
-            [''],
-            ['/'],
-            ['#about'],
-            ['?foo=bar'],
-            ['?foo=bar&baz=123'],
-            ['/index.html'],
-            ['/about/index.html'],
+            ['https://example.com'],
+            ['https://example.com/'],
+            ['https://example.com#about'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+            ['https://example.com/index.html'],
+            ['https://example.com/about/index.html'],
         ];
     }
 
@@ -52,9 +52,13 @@ final class LocationTest extends TestCase
     public function getInvalidLocations(): array
     {
         return [
+            [''],
+            ['/'],
             ['../'],
             ['index.html'],
+            ['?foo=bar'],
             ['&foo=bar'],
+            ['#'],
             ['№'],
             ['@'],
             ['\\'],
@@ -77,8 +81,9 @@ final class LocationTest extends TestCase
     {
         $this->expectException(LocationTooLongException::class);
 
-        $location_max_length = Location::MAX_LENGTH;
+        $location = 'https://example.com/';
+        $location .= str_repeat('f', Location::MAX_LENGTH - strlen($location) + 1 /* overflow */);
 
-        new Location(str_repeat('f', $location_max_length + 1));
+        new Location($location);
     }
 }

--- a/tests/Render/PlainTextSitemapIndexRenderTest.php
+++ b/tests/Render/PlainTextSitemapIndexRenderTest.php
@@ -16,8 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 final class PlainTextSitemapIndexRenderTest extends TestCase
 {
-    private const WEB_PATH = 'https://example.com';
-
     /**
      * @var PlainTextSitemapIndexRender
      */
@@ -25,7 +23,7 @@ final class PlainTextSitemapIndexRenderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->render = new PlainTextSitemapIndexRender(self::WEB_PATH);
+        $this->render = new PlainTextSitemapIndexRender();
     }
 
     /**
@@ -58,7 +56,7 @@ final class PlainTextSitemapIndexRenderTest extends TestCase
      */
     public function testStart(bool $validating, string $start_teg): void
     {
-        $render = new PlainTextSitemapIndexRender(self::WEB_PATH, $validating);
+        $render = new PlainTextSitemapIndexRender($validating);
         $expected = '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL.$start_teg;
 
         self::assertEquals($expected, $render->start());
@@ -73,13 +71,13 @@ final class PlainTextSitemapIndexRenderTest extends TestCase
 
     public function testSitemap(): void
     {
-        $path = '/sitemap1.xml';
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<sitemap>'.
-            '<loc>'.self::WEB_PATH.$path.'</loc>'.
+            '<loc>'.$url.'</loc>'.
         '</sitemap>';
 
-        self::assertEquals($expected, $this->render->sitemap(new Sitemap($path)));
+        self::assertEquals($expected, $this->render->sitemap(new Sitemap($url)));
     }
 
     /**
@@ -101,14 +99,14 @@ final class PlainTextSitemapIndexRenderTest extends TestCase
      */
     public function testSitemapWithLastMod(?\DateTimeInterface $last_modify): void
     {
-        $path = '/sitemap1.xml';
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<sitemap>'.
-            '<loc>'.self::WEB_PATH.$path.'</loc>'.
+            '<loc>'.$url.'</loc>'.
             ($last_modify ? sprintf('<lastmod>%s</lastmod>', $last_modify->format('c')) : '').
         '</sitemap>';
 
-        self::assertEquals($expected, $this->render->sitemap(new Sitemap($path, $last_modify)));
+        self::assertEquals($expected, $this->render->sitemap(new Sitemap($url, $last_modify)));
     }
 
     /**
@@ -119,24 +117,24 @@ final class PlainTextSitemapIndexRenderTest extends TestCase
      */
     public function testStreamRender(bool $validating, string $start_teg): void
     {
-        $render = new PlainTextSitemapIndexRender(self::WEB_PATH, $validating);
-        $path1 = '/sitemap1.xml';
+        $render = new PlainTextSitemapIndexRender($validating);
+        $url1 = 'https://example.com/sitemap1.xml';
         // test escaping
-        $path2 = '/sitemap1.xml?foo=\'bar\'&baz=">"&zaz=<';
+        $url2 = 'https://example.com/sitemap1.xml?foo=\'bar\'&baz=">"&zaz=<';
 
-        $actual = $render->start().$render->sitemap(new Sitemap($path1));
+        $actual = $render->start().$render->sitemap(new Sitemap($url1));
         // render end string right after render first Sitemap and before another Sitemaps
         // this is necessary to calculate the size of the sitemap index in bytes
         $end = $render->end();
-        $actual .= $render->sitemap(new Sitemap($path2)).$end;
+        $actual .= $render->sitemap(new Sitemap($url2)).$end;
 
         $expected = '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL.
             $start_teg.
                 '<sitemap>'.
-                    '<loc>'.self::WEB_PATH.$path1.'</loc>'.
+                    '<loc>'.$url1.'</loc>'.
                 '</sitemap>'.
                 '<sitemap>'.
-                    '<loc>'.htmlspecialchars(self::WEB_PATH.$path2).'</loc>'.
+                    '<loc>'.htmlspecialchars($url2).'</loc>'.
                 '</sitemap>'.
             '</sitemapindex>'.PHP_EOL
         ;

--- a/tests/Render/XMLWriterSitemapIndexRenderTest.php
+++ b/tests/Render/XMLWriterSitemapIndexRenderTest.php
@@ -21,8 +21,6 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     private const EOL = "\n";
 
-    private const WEB_PATH = 'https://example.com';
-
     /**
      * @var XMLWriterSitemapIndexRender
      */
@@ -30,7 +28,7 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->render = new XMLWriterSitemapIndexRender(self::WEB_PATH);
+        $this->render = new XMLWriterSitemapIndexRender();
     }
 
     /**
@@ -63,7 +61,7 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testStart(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
+        $render = new XMLWriterSitemapIndexRender($validating);
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.$start_teg.self::EOL;
 
         self::assertEquals($expected, $render->start());
@@ -77,7 +75,7 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testDoubleStart(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
+        $render = new XMLWriterSitemapIndexRender($validating);
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.$start_teg.self::EOL;
 
         self::assertEquals($expected, $render->start());
@@ -97,7 +95,7 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testStartEnd(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
+        $render = new XMLWriterSitemapIndexRender($validating);
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
             '</sitemapindex>'.self::EOL
@@ -108,29 +106,29 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
 
     public function testAddSitemapInNotStarted(): void
     {
-        $path = '/sitemap1.xml';
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected =
             '<sitemap>'.
-                '<loc>'.self::WEB_PATH.$path.'</loc>'.
+                '<loc>'.$url.'</loc>'.
             '</sitemap>'
         ;
 
-        self::assertEquals($expected, $this->render->sitemap(new Sitemap($path)));
+        self::assertEquals($expected, $this->render->sitemap(new Sitemap($url)));
     }
 
     public function testAddSitemapInNotStartedUseIndent(): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, false, true);
-        $path = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender(false, true);
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected =
             ' <sitemap>'.self::EOL.
-            '  <loc>'.self::WEB_PATH.$path.'</loc>'.self::EOL.
+            '  <loc>'.$url.'</loc>'.self::EOL.
             ' </sitemap>'.self::EOL
         ;
 
-        self::assertEquals($expected, $render->sitemap(new Sitemap($path)));
+        self::assertEquals($expected, $render->sitemap(new Sitemap($url)));
     }
 
     /**
@@ -141,18 +139,18 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testSitemap(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
-        $path = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating);
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
                 '<sitemap>'.
-                    '<loc>'.self::WEB_PATH.$path.'</loc>'.
+                    '<loc>'.$url.'</loc>'.
                 '</sitemap>'.
             '</sitemapindex>'.self::EOL
         ;
 
-        self::assertEquals($expected, $render->start().$render->sitemap(new Sitemap($path)).$render->end());
+        self::assertEquals($expected, $render->start().$render->sitemap(new Sitemap($url)).$render->end());
     }
 
     /**
@@ -183,19 +181,19 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
         bool $validating,
         string $start_teg
     ): void {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
-        $path = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating);
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
                 '<sitemap>'.
-                    '<loc>'.self::WEB_PATH.$path.'</loc>'.
+                    '<loc>'.$url.'</loc>'.
                     '<lastmod>'.$last_modify->format('c').'</lastmod>'.
                 '</sitemap>'.
             '</sitemapindex>'.self::EOL
         ;
 
-        $actual = $render->start().$render->sitemap(new Sitemap($path, $last_modify)).$render->end();
+        $actual = $render->start().$render->sitemap(new Sitemap($url, $last_modify)).$render->end();
         self::assertEquals($expected, $actual);
     }
 
@@ -207,18 +205,18 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testSitemapUseIndent(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating, true);
-        $path = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating, true);
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
             ' <sitemap>'.self::EOL.
-            '  <loc>'.self::WEB_PATH.$path.'</loc>'.self::EOL.
+            '  <loc>'.$url.'</loc>'.self::EOL.
             ' </sitemap>'.self::EOL.
             '</sitemapindex>'.self::EOL
         ;
 
-        self::assertEquals($expected, $render->start().$render->sitemap(new Sitemap($path)).$render->end());
+        self::assertEquals($expected, $render->start().$render->sitemap(new Sitemap($url)).$render->end());
     }
 
     /**
@@ -233,19 +231,19 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
         bool $validating,
         string $start_teg
     ): void {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating, true);
-        $path = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating, true);
+        $url = 'https://example.com/sitemap1.xml';
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
             ' <sitemap>'.self::EOL.
-            '  <loc>'.self::WEB_PATH.$path.'</loc>'.self::EOL.
+            '  <loc>'.$url.'</loc>'.self::EOL.
             '  <lastmod>'.$last_modify->format('c').'</lastmod>'.self::EOL.
             ' </sitemap>'.self::EOL.
             '</sitemapindex>'.self::EOL
         ;
 
-        $actual = $render->start().$render->sitemap(new Sitemap($path, $last_modify)).$render->end();
+        $actual = $render->start().$render->sitemap(new Sitemap($url, $last_modify)).$render->end();
 
         self::assertEquals($expected, $actual);
     }
@@ -258,24 +256,24 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testStreamRender(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating);
-        $path1 = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating);
+        $url1 = 'https://example.com/sitemap1.xml';
         // test escaping
-        $path2 = '/sitemap1.xml?foo=\'bar\'&baz=">"&zaz=<';
+        $url2 = 'https://example.com/sitemap1.xml?foo=\'bar\'&baz=">"&zaz=<';
 
-        $actual = $render->start().$render->sitemap(new Sitemap($path1));
+        $actual = $render->start().$render->sitemap(new Sitemap($url1));
         // render end string right after render first Sitemap and before another Sitemaps
         // this is necessary to calculate the size of the sitemap index in bytes
         $end = $render->end();
-        $actual .= $render->sitemap(new Sitemap($path2)).$end;
+        $actual .= $render->sitemap(new Sitemap($url2)).$end;
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
                 '<sitemap>'.
-                    '<loc>'.self::WEB_PATH.$path1.'</loc>'.
+                    '<loc>'.$url1.'</loc>'.
                 '</sitemap>'.
                 '<sitemap>'.
-                    '<loc>'.htmlspecialchars(self::WEB_PATH.$path2).'</loc>'.
+                    '<loc>'.htmlspecialchars($url2).'</loc>'.
                 '</sitemap>'.
             '</sitemapindex>'.self::EOL
         ;
@@ -291,23 +289,23 @@ final class XMLWriterSitemapIndexRenderTest extends TestCase
      */
     public function testStreamRenderUseIndent(bool $validating, string $start_teg): void
     {
-        $render = new XMLWriterSitemapIndexRender(self::WEB_PATH, $validating, true);
-        $path1 = '/sitemap1.xml';
-        $path2 = '/sitemap1.xml';
+        $render = new XMLWriterSitemapIndexRender($validating, true);
+        $url1 = 'https://example.com/sitemap1.xml';
+        $url2 = 'https://example.com/sitemap1.xml';
 
-        $actual = $render->start().$render->sitemap(new Sitemap($path1));
+        $actual = $render->start().$render->sitemap(new Sitemap($url1));
         // render end string right after render first Sitemap and before another Sitemaps
         // this is necessary to calculate the size of the sitemap index in bytes
         $end = $render->end();
-        $actual .= $render->sitemap(new Sitemap($path2)).$end;
+        $actual .= $render->sitemap(new Sitemap($url2)).$end;
 
         $expected = '<?xml version="1.0" encoding="UTF-8"?>'.self::EOL.
             $start_teg.self::EOL.
             ' <sitemap>'.self::EOL.
-            '  <loc>'.self::WEB_PATH.$path1.'</loc>'.self::EOL.
+            '  <loc>'.$url1.'</loc>'.self::EOL.
             ' </sitemap>'.self::EOL.
             ' <sitemap>'.self::EOL.
-            '  <loc>'.self::WEB_PATH.$path2.'</loc>'.self::EOL.
+            '  <loc>'.$url2.'</loc>'.self::EOL.
             ' </sitemap>'.self::EOL.
             '</sitemapindex>'.self::EOL
         ;

--- a/tests/Sitemap/SitemapTest.php
+++ b/tests/Sitemap/SitemapTest.php
@@ -23,16 +23,16 @@ final class SitemapTest extends TestCase
     public function getSitemap(): array
     {
         return [
-            ['', null],
-            ['/', new \DateTime('-1 day')],
-            ['/', new \DateTimeImmutable('-1 day')],
-            ['/index.html', null],
-            ['/about/index.html', null],
-            ['?', null],
-            ['?foo=bar', null],
-            ['?foo=bar&baz=123', null],
-            ['#', null],
-            ['#about', null],
+            ['https://example.com', null],
+            ['https://example.com/', new \DateTime('-1 day')],
+            ['https://example.com/', new \DateTimeImmutable('-1 day')],
+            ['https://example.com/index.html', null],
+            ['https://example.com/about/index.html', null],
+            ['https://example.com?', null],
+            ['https://example.com?foo=bar', null],
+            ['https://example.com?foo=bar&baz=123', null],
+            ['https://example.com#', null],
+            ['https://example.com#about', null],
         ];
     }
 
@@ -56,9 +56,13 @@ final class SitemapTest extends TestCase
     public function getInvalidLocations(): array
     {
         return [
+            [''],
+            ['/'],
             ['../'],
             ['index.html'],
+            ['?foo=bar'],
             ['&foo=bar'],
+            ['#'],
             ['№'],
             ['@'],
             ['\\'],
@@ -81,6 +85,6 @@ final class SitemapTest extends TestCase
     {
         $this->expectException(InvalidLastModifyException::class);
 
-        new Sitemap('/', new \DateTimeImmutable('+1 minutes'));
+        new Sitemap('https://example.com/', new \DateTimeImmutable('+1 minutes'));
     }
 }

--- a/tests/Stream/LoggerStreamTest.php
+++ b/tests/Stream/LoggerStreamTest.php
@@ -41,8 +41,8 @@ final class LoggerStreamTest extends TestCase
         $this->stream->open();
         $this->stream->close();
 
-        $url1 = Url::create('/');
-        $url2 = Url::createSmart('/');
+        $url1 = Url::create('https://example.com/');
+        $url2 = Url::createSmart('https://example.com/');
 
         $this->logger
             ->expects(self::at(0))

--- a/tests/Stream/MultiStreamTest.php
+++ b/tests/Stream/MultiStreamTest.php
@@ -104,9 +104,9 @@ final class MultiStreamTest extends TestCase
     {
         $i = 0;
         $urls = [
-            Url::create('/foo'),
-            Url::create('/bar'),
-            Url::create('/baz'),
+            Url::create('https://example.com/foo'),
+            Url::create('https://example.com/bar'),
+            Url::create('https://example.com/baz'),
         ];
 
         $stream = new MultiStream(...$substreams);
@@ -139,7 +139,7 @@ final class MultiStreamTest extends TestCase
     public function testReset(array $substreams): void
     {
         $i = 0;
-        $url = Url::create('/foo');
+        $url = Url::create('https://example.com/foo');
 
         $stream = new MultiStream(...$substreams);
         foreach ($substreams as $substream) {

--- a/tests/Stream/OutputStreamTest.php
+++ b/tests/Stream/OutputStreamTest.php
@@ -111,7 +111,7 @@ final class OutputStreamTest extends TestCase
     public function testPushNotOpened(): void
     {
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPushClosed(): void
@@ -120,15 +120,15 @@ final class OutputStreamTest extends TestCase
         $this->close();
 
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPush(): void
     {
         $urls = [
-            Url::create('/foo'),
-            Url::create('/bar'),
-            Url::create('/baz'),
+            Url::create('https://example.com/foo'),
+            Url::create('https://example.com/bar'),
+            Url::create('https://example.com/baz'),
         ];
 
         $this->expected_buffer .= self::OPENED;
@@ -165,7 +165,7 @@ final class OutputStreamTest extends TestCase
 
     public function testOverflowLinks(): void
     {
-        $url = Url::create('/');
+        $url = Url::create('https://example.com/');
         $this->stream->open();
         $this->render
             ->expects(self::atLeastOnce())
@@ -185,9 +185,10 @@ final class OutputStreamTest extends TestCase
     {
         $loops = (int) floor(Limiter::BYTE_LIMIT / Location::MAX_LENGTH);
         $prefix_size = Limiter::BYTE_LIMIT - ($loops * Location::MAX_LENGTH);
-        $opened = str_repeat('/', $prefix_size);
-        $location = str_repeat('/', Location::MAX_LENGTH);
-        $closed = '/'; // overflow byte
+        $opened = str_repeat('<', $prefix_size);
+        $location = 'https://example.com/';
+        $location .= str_repeat('f', Location::MAX_LENGTH - strlen($location));
+        $closed = '>'; // overflow byte
         $url = Url::create($location);
 
         $this->render

--- a/tests/Stream/Scope/LocationScopeTest.php
+++ b/tests/Stream/Scope/LocationScopeTest.php
@@ -62,6 +62,7 @@ final class LocationScopeTest extends TestCase
     {
         return [
             'another scheme' => ['https://example.com/', 'http://example.com/', false],
+            'another port' => ['https://example.com:80/', 'https://example.com:8080/', false],
             'another domain' => ['https://example.com/', 'https://example.org/', false],
             'another path' => ['https://example.com/news/', 'https://example.com/article/', false],
             'parent path' => ['https://example.com/news/', 'https://example.com/', false],

--- a/tests/Stream/Scope/LocationScopeTest.php
+++ b/tests/Stream/Scope/LocationScopeTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Tests\Stream\Scope;
+
+use GpsLab\Component\Sitemap\Location;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Scope\LocationScope;
+use PHPUnit\Framework\TestCase;
+
+final class LocationScopeTest extends TestCase
+{
+    /**
+     * @return string[][]
+     */
+    public function getInvalidScopes(): array
+    {
+        return [
+            // invalid URL
+            [''],
+            ['/'],
+            ['../'],
+            ['index.html'],
+            ['?foo=bar'],
+            ['&foo=bar'],
+            ['#'],
+            ['№'],
+            ['@'],
+            ['\\'],
+            // invalid scope
+            ['https://example.com'],
+            ['https://example.com/news/index.html'],
+            ['https://example.com#news'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidScopes
+     *
+     * @param string $scope
+     */
+    public function testInvalidScope(string $scope): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        new LocationScope($scope);
+    }
+
+    /**
+     * @return array<string, array<int, string|bool>>
+     */
+    public function getScopes(): array
+    {
+        return [
+            'another scheme' => ['https://example.com/', 'http://example.com/', false],
+            'another domain' => ['https://example.com/', 'https://example.org/', false],
+            'another path' => ['https://example.com/news/', 'https://example.com/article/', false],
+            'parent path' => ['https://example.com/news/', 'https://example.com/', false],
+            'root path' => ['https://example.com/', 'https://example.com/', true],
+            'page in root path' => ['https://example.com/', 'https://example.com/contacts.html', true],
+            'sub folder' => ['https://example.com/news/', 'https://example.com/news/', true],
+            'page in sub folder' => ['https://example.com/news/', 'https://example.com/news/index.html', true],
+        ];
+    }
+
+    /**
+     * @dataProvider getScopes
+     *
+     * @param string $scope
+     * @param string $url
+     * @param bool   $in_scope
+     */
+    public function testScope(string $scope, string $url, bool $in_scope): void
+    {
+        $location_scope = new LocationScope($scope);
+
+        self::assertSame($scope, $location_scope->getScope());
+        self::assertSame($scope, (string) $location_scope);
+
+        if ($in_scope) {
+            self::assertTrue($location_scope->inScope(new Location($url)));
+        } else {
+            self::assertFalse($location_scope->inScope(new Location($url)));
+        }
+    }
+}

--- a/tests/Stream/ScopeTrackingIndexStreamTest.php
+++ b/tests/Stream/ScopeTrackingIndexStreamTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Tests\Stream;
+
+use GpsLab\Component\Sitemap\Sitemap\Sitemap;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\IndexStream;
+use GpsLab\Component\Sitemap\Stream\ScopeTrackingIndexStream;
+use PHPUnit\Framework\TestCase;
+
+final class ScopeTrackingIndexStreamTest extends TestCase
+{
+    public function testOpenClose(): void
+    {
+        $opened = false;
+        $closed = false;
+
+        $wrapped_stream = $this->createMock(IndexStream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('open')
+            ->willReturnCallback(function () use (&$opened) {
+                $opened = true;
+            });
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('close')
+            ->willReturnCallback(function () use (&$closed) {
+                $closed = true;
+            });
+
+        $stream = new ScopeTrackingIndexStream($wrapped_stream, 'https://example.com/');
+        $stream->open();
+        $stream->close();
+
+        self::assertTrue($opened);
+        self::assertTrue($closed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getInvalidScopes(): array
+    {
+        return [
+            // invalid URL
+            [''],
+            ['/'],
+            ['../'],
+            ['index.html'],
+            ['?foo=bar'],
+            ['&foo=bar'],
+            ['#'],
+            ['№'],
+            ['@'],
+            ['\\'],
+            // invalid scope
+            ['https://example.com'],
+            ['https://example.com/news/index.html'],
+            ['https://example.com#news'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidScopes
+     *
+     * @param string $scope
+     */
+    public function testInvalidScope(string $scope): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        new ScopeTrackingIndexStream($this->createMock(IndexStream::class), $scope);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushOutOfScopeUrls(): array
+    {
+        return [
+            'another scheme' => ['https://example.com/', 'http://example.com/sitemap.xml'],
+            'another domain' => ['https://example.com/', 'https://example.org/sitemap.xml'],
+            'another path' => ['https://example.com/news/', 'https://example.com/article/sitemap.xml'],
+            'parent path' => ['https://example.com/news/', 'https://example.com/sitemap.xml'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushOutOfScopeUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPushOutOfScope(string $scope, string $url): void
+    {
+        $this->expectException(OutOfScopeException::class);
+
+        $stream = new ScopeTrackingIndexStream($this->createMock(IndexStream::class), $scope);
+        $stream->pushSitemap(new Sitemap($url));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushUrls(): array
+    {
+        return [
+            'root sitemap.xml' => ['https://example.com/', 'https://example.com/sitemap.xml'],
+            'section sitemap.xml' => ['https://example.com/news/', 'https://example.com/news/sitemap.xml'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPush(string $scope, string $url): void
+    {
+        $sitemap = new Sitemap($url);
+
+        $wrapped_stream = $this->createMock(IndexStream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('pushSitemap')
+            ->with($sitemap)
+        ;
+
+        $stream = new ScopeTrackingIndexStream($wrapped_stream, $scope);
+        $stream->pushSitemap($sitemap);
+    }
+}

--- a/tests/Stream/ScopeTrackingIndexStreamTest.php
+++ b/tests/Stream/ScopeTrackingIndexStreamTest.php
@@ -91,6 +91,7 @@ final class ScopeTrackingIndexStreamTest extends TestCase
     {
         return [
             'another scheme' => ['https://example.com/', 'http://example.com/sitemap.xml'],
+            'another port' => ['https://example.com:80/', 'https://example.com:8080/sitemap.xml'],
             'another domain' => ['https://example.com/', 'https://example.org/sitemap.xml'],
             'another path' => ['https://example.com/news/', 'https://example.com/article/sitemap.xml'],
             'parent path' => ['https://example.com/news/', 'https://example.com/sitemap.xml'],

--- a/tests/Stream/ScopeTrackingSplitStreamTest.php
+++ b/tests/Stream/ScopeTrackingSplitStreamTest.php
@@ -92,6 +92,7 @@ final class ScopeTrackingSplitStreamTest extends TestCase
     {
         return [
             'another scheme' => ['https://example.com/', 'http://example.com/'],
+            'another port' => ['https://example.com:80/', 'https://example.com:8080/'],
             'another domain' => ['https://example.com/', 'https://example.org/'],
             'another path' => ['https://example.com/news/', 'https://example.com/article/'],
             'parent path' => ['https://example.com/news/', 'https://example.com/'],
@@ -153,6 +154,7 @@ final class ScopeTrackingSplitStreamTest extends TestCase
     {
         return [
             'another scheme' => ['https://example.com/', 'http://example.com/sitemap.xml'],
+            'another port' => ['https://example.com:80/', 'https://example.com:8080/sitemap.xml'],
             'another domain' => ['https://example.com/', 'https://example.org/sitemap.xml'],
             'another path' => ['https://example.com/news/', 'https://example.com/article/sitemap.xml'],
             'parent path' => ['https://example.com/news/', 'https://example.com/sitemap.xml'],

--- a/tests/Stream/ScopeTrackingSplitStreamTest.php
+++ b/tests/Stream/ScopeTrackingSplitStreamTest.php
@@ -1,0 +1,186 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Tests\Stream;
+
+use GpsLab\Component\Sitemap\Sitemap\Sitemap;
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\ScopeTrackingSplitStream;
+use GpsLab\Component\Sitemap\Stream\SplitStream;
+use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
+
+final class ScopeTrackingSplitStreamTest extends TestCase
+{
+    public function testOpenClose(): void
+    {
+        $opened = false;
+        $closed = false;
+
+        $wrapped_stream = $this->createMock(SplitStream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('open')
+            ->willReturnCallback(function () use (&$opened) {
+                $opened = true;
+            });
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('close')
+            ->willReturnCallback(function () use (&$closed) {
+                $closed = true;
+            });
+
+        $stream = new ScopeTrackingSplitStream($wrapped_stream, 'https://example.com/');
+        $stream->open();
+        $stream->close();
+
+        self::assertTrue($opened);
+        self::assertTrue($closed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getInvalidScopes(): array
+    {
+        return [
+            // invalid URL
+            [''],
+            ['/'],
+            ['../'],
+            ['index.html'],
+            ['?foo=bar'],
+            ['&foo=bar'],
+            ['#'],
+            ['№'],
+            ['@'],
+            ['\\'],
+            // invalid scope
+            ['https://example.com'],
+            ['https://example.com/news/index.html'],
+            ['https://example.com#news'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidScopes
+     *
+     * @param string $scope
+     */
+    public function testInvalidScope(string $scope): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        new ScopeTrackingSplitStream($this->createMock(SplitStream::class), $scope);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushOutOfScopeUrls(): array
+    {
+        return [
+            'another scheme' => ['https://example.com/', 'http://example.com/'],
+            'another domain' => ['https://example.com/', 'https://example.org/'],
+            'another path' => ['https://example.com/news/', 'https://example.com/article/'],
+            'parent path' => ['https://example.com/news/', 'https://example.com/'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushOutOfScopeUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPushOutOfScope(string $scope, string $url): void
+    {
+        $this->expectException(OutOfScopeException::class);
+
+        $stream = new ScopeTrackingSplitStream($this->createMock(SplitStream::class), $scope);
+        $stream->push(Url::create($url));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushUrls(): array
+    {
+        return [
+            'root path' => ['https://example.com/', 'https://example.com/'],
+            'page in root path' => ['https://example.com/', 'https://example.com/index.html'],
+            'sub folder' => ['https://example.com/news/', 'https://example.com/news/'],
+            'page in sub folder' => ['https://example.com/news/', 'https://example.com/news/index.html'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPush(string $scope, string $url): void
+    {
+        $url = Url::create($url);
+
+        $wrapped_stream = $this->createMock(SplitStream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('push')
+            ->with($url)
+        ;
+
+        $stream = new ScopeTrackingSplitStream($wrapped_stream, $scope);
+        $stream->push($url);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getSitemapsOutOfScope(): array
+    {
+        return [
+            'another scheme' => ['https://example.com/', 'http://example.com/sitemap.xml'],
+            'another domain' => ['https://example.com/', 'https://example.org/sitemap.xml'],
+            'another path' => ['https://example.com/news/', 'https://example.com/article/sitemap.xml'],
+            'parent path' => ['https://example.com/news/', 'https://example.com/sitemap.xml'],
+        ];
+    }
+
+    /**
+     * @dataProvider getSitemapsOutOfScope
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testGetSitemapsOutOfScope(string $scope, string $url): void
+    {
+        $this->expectException(OutOfScopeException::class);
+
+        $wrapped_stream = $this->createMock(SplitStream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('getSitemaps')
+            ->willReturn(new \ArrayIterator([new Sitemap($url)]))
+        ;
+
+        $stream = new ScopeTrackingSplitStream($wrapped_stream, $scope);
+
+        foreach ($stream->getSitemaps() as $sitemap) {
+            self::assertInstanceOf(Sitemap::class, $sitemap);
+            self::assertSame($url, (string) $sitemap->getLocation());
+        }
+    }
+}

--- a/tests/Stream/ScopeTrackingStreamTest.php
+++ b/tests/Stream/ScopeTrackingStreamTest.php
@@ -91,6 +91,7 @@ final class ScopeTrackingStreamTest extends TestCase
     {
         return [
             'another scheme' => ['https://example.com/', 'http://example.com/'],
+            'another port' => ['https://example.com:80/', 'https://example.com:8080/'],
             'another domain' => ['https://example.com/', 'https://example.org/'],
             'another path' => ['https://example.com/news/', 'https://example.com/article/'],
             'parent path' => ['https://example.com/news/', 'https://example.com/'],

--- a/tests/Stream/ScopeTrackingStreamTest.php
+++ b/tests/Stream/ScopeTrackingStreamTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author  Peter Gribanov <info@peter-gribanov.ru>
+ * @license http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Sitemap\Tests\Stream;
+
+use GpsLab\Component\Sitemap\Stream\Exception\InvalidScopeException;
+use GpsLab\Component\Sitemap\Stream\Exception\OutOfScopeException;
+use GpsLab\Component\Sitemap\Stream\ScopeTrackingStream;
+use GpsLab\Component\Sitemap\Stream\Stream;
+use GpsLab\Component\Sitemap\Url\Url;
+use PHPUnit\Framework\TestCase;
+
+final class ScopeTrackingStreamTest extends TestCase
+{
+    public function testOpenClose(): void
+    {
+        $opened = false;
+        $closed = false;
+
+        $wrapped_stream = $this->createMock(Stream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('open')
+            ->willReturnCallback(function () use (&$opened) {
+                $opened = true;
+            });
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('close')
+            ->willReturnCallback(function () use (&$closed) {
+                $closed = true;
+            });
+
+        $stream = new ScopeTrackingStream($wrapped_stream, 'https://example.com/');
+        $stream->open();
+        $stream->close();
+
+        self::assertTrue($opened);
+        self::assertTrue($closed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getInvalidScopes(): array
+    {
+        return [
+            // invalid URL
+            [''],
+            ['/'],
+            ['../'],
+            ['index.html'],
+            ['?foo=bar'],
+            ['&foo=bar'],
+            ['#'],
+            ['№'],
+            ['@'],
+            ['\\'],
+            // invalid scope
+            ['https://example.com'],
+            ['https://example.com/news/index.html'],
+            ['https://example.com#news'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidScopes
+     *
+     * @param string $scope
+     */
+    public function testInvalidScope(string $scope): void
+    {
+        $this->expectException(InvalidScopeException::class);
+
+        new ScopeTrackingStream($this->createMock(Stream::class), $scope);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushOutOfScopeUrls(): array
+    {
+        return [
+            'another scheme' => ['https://example.com/', 'http://example.com/'],
+            'another domain' => ['https://example.com/', 'https://example.org/'],
+            'another path' => ['https://example.com/news/', 'https://example.com/article/'],
+            'parent path' => ['https://example.com/news/', 'https://example.com/'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushOutOfScopeUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPushOutOfScope(string $scope, string $url): void
+    {
+        $this->expectException(OutOfScopeException::class);
+
+        $stream = new ScopeTrackingStream($this->createMock(Stream::class), $scope);
+        $stream->push(Url::create($url));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getPushUrls(): array
+    {
+        return [
+            'root path' => ['https://example.com/', 'https://example.com/'],
+            'page in root path' => ['https://example.com/', 'https://example.com/contacts.html'],
+            'sub folder' => ['https://example.com/news/', 'https://example.com/news/'],
+            'page in sub folder' => ['https://example.com/news/', 'https://example.com/news/index.html'],
+        ];
+    }
+
+    /**
+     * @dataProvider getPushUrls
+     *
+     * @param string $scope
+     * @param string $url
+     */
+    public function testPush(string $scope, string $url): void
+    {
+        $url = Url::create($url);
+
+        $wrapped_stream = $this->createMock(Stream::class);
+        $wrapped_stream
+            ->expects(self::once())
+            ->method('push')
+            ->with($url)
+        ;
+
+        $stream = new ScopeTrackingStream($wrapped_stream, $scope);
+        $stream->push($url);
+    }
+}

--- a/tests/Stream/WritingIndexStreamTest.php
+++ b/tests/Stream/WritingIndexStreamTest.php
@@ -115,7 +115,7 @@ final class WritingIndexStreamTest extends TestCase
     public function testPushNotOpened(): void
     {
         $this->expectException(StreamStateException::class);
-        $this->stream->pushSitemap(new Sitemap('/sitemap_news.xml'));
+        $this->stream->pushSitemap(new Sitemap('https://example.com/sitemap_news.xml'));
     }
 
     public function testPushAfterClosed(): void
@@ -124,15 +124,15 @@ final class WritingIndexStreamTest extends TestCase
         $this->stream->close();
 
         $this->expectException(StreamStateException::class);
-        $this->stream->pushSitemap(new Sitemap('/sitemap_news.xml'));
+        $this->stream->pushSitemap(new Sitemap('https://example.com/sitemap_news.xml'));
     }
 
     public function testPush(): void
     {
         $sitemaps = [
-            new Sitemap('/sitemap_foo.xml'),
-            new Sitemap('/sitemap_bar.xml'),
-            new Sitemap('/sitemap_baz.xml'),
+            new Sitemap('https://example.com/sitemap_foo.xml'),
+            new Sitemap('https://example.com/sitemap_bar.xml'),
+            new Sitemap('https://example.com/sitemap_baz.xml'),
         ];
 
         // build expects
@@ -152,7 +152,7 @@ final class WritingIndexStreamTest extends TestCase
 
     public function testOverflowLinks(): void
     {
-        $sitemap = new Sitemap('/sitemap_news.xml');
+        $sitemap = new Sitemap('https://example.com/sitemap_news.xml');
 
         $this->stream->open();
 

--- a/tests/Stream/WritingSplitStreamTest.php
+++ b/tests/Stream/WritingSplitStreamTest.php
@@ -42,7 +42,7 @@ final class WritingSplitStreamTest extends TestCase
     /**
      * @var string
      */
-    private const WEB_PATH = '/sitemap%d.xml.gz';
+    private const WEB_PATH = 'https://example.com/sitemap%d.xml.gz';
 
     /**
      * @var MockObject&SitemapRender
@@ -75,7 +75,7 @@ final class WritingSplitStreamTest extends TestCase
         $this->write_call = 0;
         $this->render = $this->createMock(SitemapRender::class);
         $this->writer = $this->createMock(Writer::class);
-        $this->stream = new WritingSplitStream($this->render, $this->writer, self::FILENAME);
+        $this->stream = new WritingSplitStream($this->render, $this->writer, self::FILENAME, self::WEB_PATH);
     }
 
     public function testOpenClose(): void
@@ -122,7 +122,7 @@ final class WritingSplitStreamTest extends TestCase
     public function testPushNotOpened(): void
     {
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPushAfterClosed(): void
@@ -131,15 +131,15 @@ final class WritingSplitStreamTest extends TestCase
         $this->stream->close();
 
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPush(): void
     {
         $urls = [
-            Url::create('/foo'),
-            Url::create('/bar'),
-            Url::create('/baz'),
+            Url::create('https://example.com/foo'),
+            Url::create('https://example.com/bar'),
+            Url::create('https://example.com/baz'),
         ];
 
         // build expects
@@ -206,7 +206,7 @@ final class WritingSplitStreamTest extends TestCase
 
     public function testGetSitemaps(): void
     {
-        $url = Url::create('/');
+        $url = Url::create('https://example.com/');
         $now = time();
 
         $this->expectOpen();
@@ -233,7 +233,7 @@ final class WritingSplitStreamTest extends TestCase
 
     public function testSplitOverflowLinks(): void
     {
-        $url = Url::create('/');
+        $url = Url::create('https://example.com/');
         $now = time();
         $overflow = 10;
 
@@ -294,9 +294,10 @@ final class WritingSplitStreamTest extends TestCase
     {
         $loops = (int) floor(Limiter::BYTE_LIMIT / Location::MAX_LENGTH);
         $prefix_size = Limiter::BYTE_LIMIT - ($loops * Location::MAX_LENGTH);
-        $opened = str_repeat('/', $prefix_size);
-        $location = str_repeat('/', Location::MAX_LENGTH);
-        $closed = '/'; // overflow byte
+        $opened = str_repeat('<', $prefix_size);
+        $location = 'https://example.com/';
+        $location .= str_repeat('f', Location::MAX_LENGTH - strlen($location));
+        $closed = '>'; // overflow byte
 
         $url = Url::create($location);
         $now = time();

--- a/tests/Stream/WritingStreamTest.php
+++ b/tests/Stream/WritingStreamTest.php
@@ -117,7 +117,7 @@ final class WritingStreamTest extends TestCase
     public function testPushNotOpened(): void
     {
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPushAfterClosed(): void
@@ -126,15 +126,15 @@ final class WritingStreamTest extends TestCase
         $this->stream->close();
 
         $this->expectException(StreamStateException::class);
-        $this->stream->push(Url::create('/'));
+        $this->stream->push(Url::create('https://example.com/'));
     }
 
     public function testPush(): void
     {
         $urls = [
-            Url::create('/foo'),
-            Url::create('/bar'),
-            Url::create('/baz'),
+            Url::create('https://example.com/foo'),
+            Url::create('https://example.com/bar'),
+            Url::create('https://example.com/baz'),
         ];
 
         // build expects
@@ -154,7 +154,7 @@ final class WritingStreamTest extends TestCase
 
     public function testOverflowLinks(): void
     {
-        $url = Url::create('/');
+        $url = Url::create('https://example.com/');
 
         $this->stream->open();
 
@@ -170,9 +170,10 @@ final class WritingStreamTest extends TestCase
     {
         $loops = (int) floor(Limiter::BYTE_LIMIT / Location::MAX_LENGTH);
         $prefix_size = Limiter::BYTE_LIMIT - ($loops * Location::MAX_LENGTH);
-        $opened = str_repeat('/', $prefix_size);
-        $location = str_repeat('/', Location::MAX_LENGTH);
-        $closed = '/'; // overflow byte
+        $opened = str_repeat('<', $prefix_size);
+        $location = 'https://example.com/';
+        $location .= str_repeat('f', Location::MAX_LENGTH - strlen($location));
+        $closed = '>'; // overflow byte
 
         $url = Url::create($location);
 

--- a/tests/Url/LanguageTest.php
+++ b/tests/Url/LanguageTest.php
@@ -44,7 +44,7 @@ final class LanguageTest extends TestCase
     {
         $this->expectException(InvalidLanguageException::class);
 
-        new Language($language, '');
+        new Language($language, 'https://example.com');
     }
 
     /**
@@ -53,9 +53,13 @@ final class LanguageTest extends TestCase
     public function getInvalidLocations(): array
     {
         return [
+            [''],
+            ['/'],
             ['../'],
             ['index.html'],
+            ['?foo=bar'],
             ['&foo=bar'],
+            ['#'],
             ['№'],
             ['@'],
             ['\\'],
@@ -82,17 +86,13 @@ final class LanguageTest extends TestCase
         $result = [];
         $languages = ['x-default'];
         $locations = [
-            '',
-            '/',
-            '#about',
-            '?foo=bar',
-            '?foo=bar&baz=123',
-            '/index.html',
-            '/about/index.html',
-        ];
-        $web_paths = [
             'https://example.com',
-            'http://example.org/catalog',
+            'https://example.com/',
+            'https://example.com#about',
+            'https://example.com?foo=bar',
+            'https://example.com?foo=bar&baz=123',
+            'https://example.com/index.html',
+            'https://example.com/about/index.html',
         ];
 
         // build list $languages
@@ -113,15 +113,6 @@ final class LanguageTest extends TestCase
             }
         }
 
-        // build remote locations
-        foreach ($web_paths as $web_path) {
-            foreach ($locations as $location) {
-                foreach ($languages as $language) {
-                    $result[] = [$language, $web_path.$location, false];
-                }
-            }
-        }
-
         return $result;
     }
 
@@ -130,18 +121,11 @@ final class LanguageTest extends TestCase
      *
      * @param string $language
      * @param string $location
-     * @param bool   $local
      */
-    public function testLanguage(string $language, string $location, bool $local): void
+    public function testLanguage(string $language, string $location): void
     {
         $lang = new Language($language, $location);
         self::assertSame($language, $lang->getLanguage());
-        self::assertSame($location, $lang->getLocation());
-
-        if ($local) {
-            self::assertTrue($lang->isLocalLocation());
-        } else {
-            self::assertFalse($lang->isLocalLocation());
-        }
+        self::assertSame($location, (string) $lang->getLocation());
     }
 }

--- a/tests/Url/PriorityTest.php
+++ b/tests/Url/PriorityTest.php
@@ -108,19 +108,19 @@ final class PriorityTest extends TestCase
     public function getPriorityOfLocations(): array
     {
         return [
-            ['/', '1.0'],
-            ['/index.html', '0.9'],
-            ['/catalog', '0.9'],
-            ['/catalog/123', '0.8'],
-            ['/catalog/123/article', '0.7'],
-            ['/catalog/123/article/456', '0.6'],
-            ['/catalog/123/article/456/print', '0.5'],
-            ['/catalog/123/subcatalog/789/article/456', '0.4'],
-            ['/catalog/123/subcatalog/789/article/456/print', '0.3'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo', '0.2'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar', '0.1'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar/baz', '0.1'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar/baz/qux', '0.1'],
+            ['https://example.com/', '1.0'],
+            ['https://example.com/index.html', '0.9'],
+            ['https://example.com/catalog', '0.9'],
+            ['https://example.com/catalog/123', '0.8'],
+            ['https://example.com/catalog/123/article', '0.7'],
+            ['https://example.com/catalog/123/article/456', '0.6'],
+            ['https://example.com/catalog/123/article/456/print', '0.5'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456', '0.4'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print', '0.3'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo', '0.2'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar', '0.1'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz', '0.1'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz/qux', '0.1'],
         ];
     }
 

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -25,7 +25,7 @@ final class UrlTest extends TestCase
 {
     public function testDefaultUrl(): void
     {
-        $location = '';
+        $location = 'https://example.com';
         $url = Url::create($location);
 
         self::assertEquals($location, (string) $url->getLocation());
@@ -37,7 +37,7 @@ final class UrlTest extends TestCase
 
     public function testDefaultSmartUrl(): void
     {
-        $location = '';
+        $location = 'https://example.com';
         $url = Url::createSmart($location);
 
         $priority = Priority::createByLocation(new Location($location));
@@ -81,7 +81,7 @@ final class UrlTest extends TestCase
      */
     public function testCustomUrl(\DateTimeInterface $last_modify, string $change_frequency, string $priority): void
     {
-        $location = '/index.html';
+        $location = 'https://example.com/index.html';
 
         $url = Url::create($location, $last_modify, $change_frequency, $priority);
 
@@ -103,7 +103,7 @@ final class UrlTest extends TestCase
         string $change_frequency,
         string $priority
     ): void {
-        $location = '/index.html';
+        $location = 'https://example.com/index.html';
 
         $url = Url::createSmart($location, $last_modify, $change_frequency, $priority);
 
@@ -119,9 +119,13 @@ final class UrlTest extends TestCase
     public function getInvalidLocations(): array
     {
         return [
+            [''],
+            ['/'],
             ['../'],
             ['index.html'],
+            ['?foo=bar'],
             ['&foo=bar'],
+            ['#'],
             ['№'],
             ['@'],
             ['\\'],
@@ -158,13 +162,13 @@ final class UrlTest extends TestCase
     public function getValidLocations(): array
     {
         return [
-            [''],
-            ['/'],
-            ['#about'],
-            ['?foo=bar'],
-            ['?foo=bar&baz=123'],
-            ['/index.html'],
-            ['/about/index.html'],
+            ['https://example.com'],
+            ['https://example.com/'],
+            ['https://example.com#about'],
+            ['https://example.com?foo=bar'],
+            ['https://example.com?foo=bar&baz=123'],
+            ['https://example.com/index.html'],
+            ['https://example.com/about/index.html'],
         ];
     }
 
@@ -192,53 +196,53 @@ final class UrlTest extends TestCase
     {
         $this->expectException(InvalidLastModifyException::class);
 
-        Url::create('/', new \DateTimeImmutable('+1 minutes'));
+        Url::create('https://example.com/', new \DateTimeImmutable('+1 minutes'));
     }
 
     public function testInvalidSmartLastModify(): void
     {
         $this->expectException(InvalidLastModifyException::class);
 
-        Url::createSmart('/', new \DateTimeImmutable('+1 minutes'));
+        Url::createSmart('https://example.com/', new \DateTimeImmutable('+1 minutes'));
     }
 
     public function testInvalidPriority(): void
     {
         $this->expectException(InvalidPriorityException::class);
 
-        Url::create('/', null, null, 11);
+        Url::create('https://example.com/', null, null, 11);
     }
 
     public function testInvalidSmartPriority(): void
     {
         $this->expectException(InvalidPriorityException::class);
 
-        Url::createSmart('/', null, null, 11);
+        Url::createSmart('https://example.com/', null, null, 11);
     }
 
     public function testInvalidChangeFrequency(): void
     {
         $this->expectException(InvalidChangeFrequencyException::class);
 
-        Url::create('/', null, '');
+        Url::create('https://example.com/', null, '');
     }
 
     public function testInvalidSmartChangeFrequency(): void
     {
         $this->expectException(InvalidChangeFrequencyException::class);
 
-        Url::createSmart('/', null, '');
+        Url::createSmart('https://example.com/', null, '');
     }
 
     public function testGetLanguages(): void
     {
         $languages = [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
         ];
 
-        $url = Url::create('/english/page.html', null, null, null, $languages);
+        $url = Url::create('https://example.com/english/page.html', null, null, null, $languages);
 
         self::assertNotEmpty($url->getLanguages());
 
@@ -247,19 +251,19 @@ final class UrlTest extends TestCase
         foreach ($url->getLanguages() as $j => $language) {
             self::assertInstanceOf(Language::class, $language);
             self::assertSame($keys[$j], $language->getLanguage());
-            self::assertSame($languages[$keys[$j]], $language->getLocation());
+            self::assertSame($languages[$keys[$j]], (string) $language->getLocation());
         }
     }
 
     public function testGetSmartLanguages(): void
     {
         $languages = [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
         ];
 
-        $url = Url::createSmart('/english/page.html', null, null, null, $languages);
+        $url = Url::createSmart('https://example.com/english/page.html', null, null, null, $languages);
 
         self::assertNotEmpty($url->getLanguages());
 
@@ -268,7 +272,7 @@ final class UrlTest extends TestCase
         foreach ($url->getLanguages() as $j => $language) {
             self::assertInstanceOf(Language::class, $language);
             self::assertSame($keys[$j], $language->getLanguage());
-            self::assertSame($languages[$keys[$j]], $language->getLocation());
+            self::assertSame($languages[$keys[$j]], (string) $language->getLocation());
         }
     }
 
@@ -285,9 +289,9 @@ final class UrlTest extends TestCase
         string $priority
     ): void {
         $languages = [
-            'de' => '/deutsch/page.html',
-            'de-ch' => '/schweiz-deutsch/page.html',
-            'en' => '/english/page.html',
+            'de' => 'https://example.com/deutsch/page.html',
+            'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+            'en' => 'https://example.com/english/page.html',
         ];
         $external_languages = [
             'de' => 'https://example.de', // should be overwritten from $languages
@@ -311,7 +315,7 @@ final class UrlTest extends TestCase
             foreach ($url->getLanguages() as $j => $language) {
                 self::assertInstanceOf(Language::class, $language);
                 self::assertSame($keys[$j], $language->getLanguage());
-                self::assertSame($expected_languages[$keys[$j]], $language->getLocation());
+                self::assertSame($expected_languages[$keys[$j]], (string) $language->getLocation());
             }
         }
     }
@@ -324,41 +328,41 @@ final class UrlTest extends TestCase
         return [
             [
                 [
-                    'de' => '/deutsch/page.html',
-                    'de-ch' => '/schweiz-deutsch/page.html',
-                    'en' => '/english/page.html',
-                    'x-default' => '/english/page.html',
+                    'de' => 'https://example.com/deutsch/page.html',
+                    'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+                    'en' => 'https://example.com/english/page.html',
+                    'x-default' => 'https://example.com/english/page.html',
                 ],
                 [
-                    '/deutsch/page.html',
-                    '/schweiz-deutsch/page.html',
-                    '/english/page.html',
-                ],
-            ],
-            [
-                [
-                    'de' => '/deutsch/page.html',
-                    'de-ch' => '/schweiz-deutsch/page.html',
-                    'x-default' => '/english/page.html', // unmatched language
-                ],
-                [
-                    '/deutsch/page.html',
-                    '/schweiz-deutsch/page.html',
-                    '/english/page.html',
+                    'https://example.com/deutsch/page.html',
+                    'https://example.com/schweiz-deutsch/page.html',
+                    'https://example.com/english/page.html',
                 ],
             ],
             [
                 [
-                    'de' => '/deutsch/page.html',
-                    'de-ch' => '/schweiz-deutsch/page.html',
-                    'en' => '/english/page.html',
-                    'en-US' => '/english/page.html',
-                    'en-GB' => '/english/page.html',
+                    'de' => 'https://example.com/deutsch/page.html',
+                    'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+                    'x-default' => 'https://example.com/english/page.html', // unmatched language
                 ],
                 [
-                    '/deutsch/page.html',
-                    '/schweiz-deutsch/page.html',
-                    '/english/page.html',
+                    'https://example.com/deutsch/page.html',
+                    'https://example.com/schweiz-deutsch/page.html',
+                    'https://example.com/english/page.html',
+                ],
+            ],
+            [
+                [
+                    'de' => 'https://example.com/deutsch/page.html',
+                    'de-ch' => 'https://example.com/schweiz-deutsch/page.html',
+                    'en' => 'https://example.com/english/page.html',
+                    'en-US' => 'https://example.com/english/page.html',
+                    'en-GB' => 'https://example.com/english/page.html',
+                ],
+                [
+                    'https://example.com/deutsch/page.html',
+                    'https://example.com/schweiz-deutsch/page.html',
+                    'https://example.com/english/page.html',
                 ],
             ],
         ];
@@ -384,7 +388,7 @@ final class UrlTest extends TestCase
             foreach ($url->getLanguages() as $j => $language) {
                 self::assertInstanceOf(Language::class, $language);
                 self::assertSame($keys[$j], $language->getLanguage());
-                self::assertSame($languages[$keys[$j]], $language->getLocation());
+                self::assertSame($languages[$keys[$j]], (string) $language->getLocation());
             }
         }
     }
@@ -395,19 +399,19 @@ final class UrlTest extends TestCase
     public function getPriorityOfLocations(): array
     {
         return [
-            ['/', '1.0'],
-            ['/index.html', '0.9'],
-            ['/catalog', '0.9'],
-            ['/catalog/123', '0.8'],
-            ['/catalog/123/article', '0.7'],
-            ['/catalog/123/article/456', '0.6'],
-            ['/catalog/123/article/456/print', '0.5'],
-            ['/catalog/123/subcatalog/789/article/456', '0.4'],
-            ['/catalog/123/subcatalog/789/article/456/print', '0.3'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo', '0.2'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar', '0.1'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar/baz', '0.1'],
-            ['/catalog/123/subcatalog/789/article/456/print/foo/bar/baz/qux', '0.1'],
+            ['https://example.com/', '1.0'],
+            ['https://example.com/index.html', '0.9'],
+            ['https://example.com/catalog', '0.9'],
+            ['https://example.com/catalog/123', '0.8'],
+            ['https://example.com/catalog/123/article', '0.7'],
+            ['https://example.com/catalog/123/article/456', '0.6'],
+            ['https://example.com/catalog/123/article/456/print', '0.5'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456', '0.4'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print', '0.3'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo', '0.2'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar', '0.1'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz', '0.1'],
+            ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz/qux', '0.1'],
         ];
     }
 
@@ -452,7 +456,7 @@ final class UrlTest extends TestCase
         \DateTimeInterface $last_modify,
         string $change_frequency
     ): void {
-        $location = '/';
+        $location = 'https://example.com/';
         $url = Url::createSmart($location, $last_modify);
 
         self::assertEquals($location, (string) $url->getLocation());
@@ -488,7 +492,7 @@ final class UrlTest extends TestCase
      */
     public function testSmartChangeFrequencyFromPriority(string $priority, string $change_frequency): void
     {
-        $location = '/';
+        $location = 'https://example.com/';
         $url = Url::createSmart($location, null, null, $priority);
 
         self::assertEquals($location, (string) $url->getLocation());


### PR DESCRIPTION
The Sitemap protocol imposes restrictions on the URLs that can be specified in it, depending on the location of the
Sitemap file:

 * All URLs listed in the Sitemap must use the same protocol (`https`, in this example) and reside on
   the same host as the Sitemap. For instance, if the Sitemap is located at `https://www.example.com/sitemap.xml`, it
   can't include URLs from `http://www.example.com/` or `https://subdomain.example.com`.
 * The location of a Sitemap file determines the set of URLs that can be included in that Sitemap. A Sitemap file
   located at `https://example.com/catalog/sitemap.xml` can include any URLs starting with
   `https://example.com/catalog/` but can not include URLs starting with `https://example.com/news/`.
 * If you submit a Sitemap using a path with a port number, you must include that port number as part of the path in
   each URL listed in the Sitemap file. For instance, if your Sitemap is located at
   `http://www.example.com:100/sitemap.xml`, then each URL listed in the Sitemap must begin with
   `http://www.example.com:100`.
 * A Sitemap index file can only specify Sitemaps that are found on the same site as the Sitemap index file. For
    example, `https://www.yoursite.com/sitemap_index.xml` can include Sitemaps on `https://www.yoursite.com` but not on
    `http://www.yoursite.com`, `https://www.example.com` or `https://yourhost.yoursite.com`.

URLs that are not considered valid may be dropped from further consideration by search engine crawlers. We do not check
these restrictions to improve performance and because we trust the developers, but you can enable checking for these
restrictions with the appropriate decorators. It is better to detect a problem during the sitemap build process than
during indexing.