### PR TITLE
Correct calculate path nesting level

### DIFF
--- a/src/Url/Priority.php
+++ b/src/Url/Priority.php
@@ -97,13 +97,13 @@ final class Priority
     {
         $path = (string) parse_url($location->getLocation(), PHP_URL_PATH);
         $path = trim($path, '/');
-        $number_of_slashes = substr_count($path, '/');
+        $path_nesting_level = count(array_filter(explode('/', $path)));
 
-        if ($number_of_slashes === 0) {
+        if ($path_nesting_level === 0) {
             return self::safeCreate('1.0');
         }
 
-        $priority = (10 - $number_of_slashes) / 10;
+        $priority = (10 - $path_nesting_level) / 10;
 
         if ($priority > 0) {
             return self::safeCreate(number_format($priority, 1));

--- a/tests/Url/PriorityTest.php
+++ b/tests/Url/PriorityTest.php
@@ -121,6 +121,7 @@ final class PriorityTest extends TestCase
             ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar', '0.1'],
             ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz', '0.1'],
             ['https://example.com/catalog/123/subcatalog/789/article/456/print/foo/bar/baz/qux', '0.1'],
+            ['https://example.com///catalog///123', '0.8'],
         ];
     }
 


### PR DESCRIPTION
The `substr_count()` function calculate a number of slashes, not a path nesting level.

| URL | `substr_count` | `count` |
| -- | -- | -- |
| `https://example.com/` | `0` | `0` |
| `https://example.com/index.html` | `1` | `0` |
| `https://example.com///catalog///123` | `2` | `3` |
