### PR TITLE
Fix invalid XML namespace

### DIFF
--- a/src/Render/PlainTextSitemapRender.php
+++ b/src/Render/PlainTextSitemapRender.php
@@ -39,12 +39,12 @@ final class PlainTextSitemapRender implements SitemapRender
                 ' xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9'.
                 ' http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"'.
                 ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.
-                ' xmlns:xhtml="https://www.w3.org/1999/xhtml"'.
+                ' xmlns:xhtml="http://www.w3.org/1999/xhtml"'.
                 '>';
         }
 
         return '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL.
-            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml">';
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">';
     }
 
     /**

--- a/src/Render/XMLWriterSitemapRender.php
+++ b/src/Render/XMLWriterSitemapRender.php
@@ -64,7 +64,7 @@ final class XMLWriterSitemapRender implements SitemapRender
         }
 
         $this->writer->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-        $this->writer->writeAttribute('xmlns:xhtml', 'https://www.w3.org/1999/xhtml');
+        $this->writer->writeAttribute('xmlns:xhtml', 'http://www.w3.org/1999/xhtml');
 
         // XMLWriter expects that we can add more attributes
         // we force XMLWriter to set the closing bracket ">"

--- a/tests/Render/PlainTextSitemapRenderTest.php
+++ b/tests/Render/PlainTextSitemapRenderTest.php
@@ -37,7 +37,7 @@ final class PlainTextSitemapRenderTest extends TestCase
                 false,
                 '<urlset'.
                 ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.
-                ' xmlns:xhtml="https://www.w3.org/1999/xhtml"'.
+                ' xmlns:xhtml="http://www.w3.org/1999/xhtml"'.
                 '>',
             ],
             [
@@ -47,7 +47,7 @@ final class PlainTextSitemapRenderTest extends TestCase
                 ' xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9'.
                 ' http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"'.
                 ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.
-                ' xmlns:xhtml="https://www.w3.org/1999/xhtml"'.
+                ' xmlns:xhtml="http://www.w3.org/1999/xhtml"'.
                 '>',
             ],
         ];

--- a/tests/Render/XMLWriterSitemapRenderTest.php
+++ b/tests/Render/XMLWriterSitemapRenderTest.php
@@ -42,7 +42,7 @@ final class XMLWriterSitemapRenderTest extends TestCase
                 false,
                 '<urlset'.
                 ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.
-                ' xmlns:xhtml="https://www.w3.org/1999/xhtml"'.
+                ' xmlns:xhtml="http://www.w3.org/1999/xhtml"'.
                 '>',
             ],
             [
@@ -52,7 +52,7 @@ final class XMLWriterSitemapRenderTest extends TestCase
                 ' xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9'.
                 ' http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"'.
                 ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.
-                ' xmlns:xhtml="https://www.w3.org/1999/xhtml"'.
+                ' xmlns:xhtml="http://www.w3.org/1999/xhtml"'.
                 '>',
             ],
         ];


### PR DESCRIPTION
Although it's possible to view the web page contents of the [referenced namespace](https://www.w3.org/1999/xhtml/), the only valid name for the namespace is `http://www.w3.org/1999/xhtml`.

The XML namespace [specification](https://www.w3.org/TR/REC-xml-names/#NSNameComparison) is clear when a namespace reference is considered identical:

> [Definition: The two URIs are treated as strings, and they are identical if and only if the strings are identical, that is, if they are the same sequence of characters. ] The comparison is case-sensitive, and no %-escaping is done or undone.

---

The error is evident from the GSC (Google Search Console) when it analyzes a sitemap generated by the library:

> Your Sitemap or Sitemap index file doesn't properly declare the namespace. Expected: http://www.w3.org/1999/xhtml Found: https://www.w3.org/1999/xhtml